### PR TITLE
feat: add order and transaction modules

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
+import { TransactionModule } from './transaction/transaction.module';
+import { OrderModule } from './order/order.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, TransactionModule, OrderModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/order/dto/create-order.dto.ts
+++ b/src/order/dto/create-order.dto.ts
@@ -1,0 +1,21 @@
+export class CreateOrderDto {
+  product: string;
+  orderId: string;
+  orderNumber: string;
+  postingNumber: string;
+  status: string;
+  createdAt: Date;
+  inProcessAt: Date;
+  deliveryType: string;
+  city?: string;
+  isPremium: boolean;
+  paymentTypeGroupName: string;
+  warehouseId: string;
+  warehouseName: string;
+  sku: string;
+  oldPrice: number;
+  price: number;
+  currencyCode: string;
+  clusterFrom: string;
+  clusterTo: string;
+}

--- a/src/order/dto/update-order.dto.ts
+++ b/src/order/dto/update-order.dto.ts
@@ -1,0 +1,3 @@
+import { CreateOrderDto } from './create-order.dto';
+
+export type UpdateOrderDto = Partial<CreateOrderDto>;

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
+import { OrderService } from './order.service';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+
+@Controller('orders')
+export class OrderController {
+  constructor(private readonly orderService: OrderService) {}
+
+  @Post()
+  create(@Body() dto: CreateOrderDto) {
+    return this.orderService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.orderService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.orderService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateOrderDto) {
+    return this.orderService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.orderService.remove(id);
+  }
+}

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { OrderService } from './order.service';
+import { OrderController } from './order.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [OrderController],
+  providers: [OrderService],
+})
+export class OrderModule {}

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+
+@Injectable()
+export class OrderService {
+  constructor(private prisma: PrismaService) {}
+
+  create(data: CreateOrderDto) {
+    return this.prisma.order.create({ data });
+  }
+
+  findAll() {
+    return this.prisma.order.findMany();
+  }
+
+  findOne(id: string) {
+    return this.prisma.order.findUnique({ where: { id } });
+  }
+
+  update(id: string, data: UpdateOrderDto) {
+    return this.prisma.order.update({ where: { id }, data });
+  }
+
+  remove(id: string) {
+    return this.prisma.order.delete({ where: { id } });
+  }
+}

--- a/src/transaction/dto/create-transaction.dto.ts
+++ b/src/transaction/dto/create-transaction.dto.ts
@@ -1,0 +1,9 @@
+export class CreateTransactionDto {
+  operationType: string;
+  operationTypeName: string;
+  operationServiceName: string;
+  date: Date;
+  type: string;
+  postingNumber: string;
+  price: number;
+}

--- a/src/transaction/dto/update-transaction.dto.ts
+++ b/src/transaction/dto/update-transaction.dto.ts
@@ -1,0 +1,3 @@
+import { CreateTransactionDto } from './create-transaction.dto';
+
+export type UpdateTransactionDto = Partial<CreateTransactionDto>;

--- a/src/transaction/transaction.controller.ts
+++ b/src/transaction/transaction.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
+import { TransactionService } from './transaction.service';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { UpdateTransactionDto } from './dto/update-transaction.dto';
+
+@Controller('transactions')
+export class TransactionController {
+  constructor(private readonly transactionService: TransactionService) {}
+
+  @Post()
+  create(@Body() dto: CreateTransactionDto) {
+    return this.transactionService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.transactionService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.transactionService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateTransactionDto) {
+    return this.transactionService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.transactionService.remove(id);
+  }
+}

--- a/src/transaction/transaction.module.ts
+++ b/src/transaction/transaction.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TransactionService } from './transaction.service';
+import { TransactionController } from './transaction.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TransactionController],
+  providers: [TransactionService],
+})
+export class TransactionModule {}

--- a/src/transaction/transaction.service.ts
+++ b/src/transaction/transaction.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { UpdateTransactionDto } from './dto/update-transaction.dto';
+
+@Injectable()
+export class TransactionService {
+  constructor(private prisma: PrismaService) {}
+
+  create(data: CreateTransactionDto) {
+    return this.prisma.transaction.create({ data });
+  }
+
+  findAll() {
+    return this.prisma.transaction.findMany();
+  }
+
+  findOne(id: string) {
+    return this.prisma.transaction.findUnique({ where: { id } });
+  }
+
+  update(id: string, data: UpdateTransactionDto) {
+    return this.prisma.transaction.update({ where: { id }, data });
+  }
+
+  remove(id: string) {
+    return this.prisma.transaction.delete({ where: { id } });
+  }
+}


### PR DESCRIPTION
## Summary
- add Transaction module with CRUD service and DTOs matching Prisma schema
- add Order module with Prisma-backed service and DTO definitions
- wire new modules into main AppModule

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@nestjs%2fcli)*

------
https://chatgpt.com/codex/tasks/task_e_68c412dc7330832abe0d1c36f00cb0cd