### PR TITLE
feat: add ozon api clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^5.15.0",
+    "axios": "^1.6.7",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.0"
   },

--- a/src/api/performanceClient.ts
+++ b/src/api/performanceClient.ts
@@ -1,0 +1,58 @@
+import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import { PERFORMANCE_CLIENT_ID, PERFORMANCE_CLIENT_SECRET } from '@/config';
+import { waitRateLimit } from '@/shared/utils/rateLimit';
+
+let performanceToken: string | null = null;
+let performanceTokenExpiry = 0;
+
+const refreshPerformanceToken = async (): Promise<string> => {
+  const now = Date.now();
+
+  if (performanceToken && now < performanceTokenExpiry) {
+    return performanceToken;
+  }
+
+  await waitRateLimit();
+
+  const response = await axios.post(
+    'https://api-performance.ozon.ru:443/api/client/token',
+    {
+      client_id: PERFORMANCE_CLIENT_ID,
+      client_secret: PERFORMANCE_CLIENT_SECRET,
+      grant_type: 'client_credentials',
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+
+  const data = response.data;
+
+  performanceToken = data.access_token;
+  performanceTokenExpiry = now + data.expires_in * 1000 - 60_000;
+
+  return performanceToken;
+};
+
+const performanceClient: AxiosInstance = axios.create({
+  baseURL: 'https://api-performance.ozon.ru:443/',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+performanceClient.interceptors.request.use(
+  async (
+    config: InternalAxiosRequestConfig,
+  ): Promise<InternalAxiosRequestConfig> => {
+    await waitRateLimit();
+    config.headers = config.headers ?? {};
+    const token = await refreshPerformanceToken();
+    config.headers['Authorization'] = `Bearer ${token}`;
+    return config;
+  },
+);
+
+export { performanceClient };

--- a/src/api/sellerClient.ts
+++ b/src/api/sellerClient.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { SELLER_CLIENT_ID, SELLER_API_KEY } from '@/config';
+import { waitRateLimit } from '@/shared/utils/rateLimit';
+
+export const sellerClient = axios.create({
+  baseURL: 'https://api-seller.ozon.ru',
+  headers: {
+    'Content-Type': 'application/json',
+    'Client-Id': SELLER_CLIENT_ID,
+    'Api-Key': SELLER_API_KEY,
+  },
+});
+
+sellerClient.interceptors.request.use(async config => {
+  await waitRateLimit();
+  return config;
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,4 @@
+export const SELLER_CLIENT_ID = process.env.SELLER_CLIENT_ID ?? '';
+export const SELLER_API_KEY = process.env.SELLER_API_KEY ?? '';
+export const PERFORMANCE_CLIENT_ID = process.env.PERFORMANCE_CLIENT_ID ?? '';
+export const PERFORMANCE_CLIENT_SECRET = process.env.PERFORMANCE_CLIENT_SECRET ?? '';

--- a/src/shared/utils/rateLimit.ts
+++ b/src/shared/utils/rateLimit.ts
@@ -1,0 +1,13 @@
+const RATE_LIMIT_DELAY = 300;
+
+let lastCall = 0;
+
+export const waitRateLimit = async (): Promise<void> => {
+  const now = Date.now();
+  const elapsed = now - lastCall;
+  const waitTime = Math.max(0, RATE_LIMIT_DELAY - elapsed);
+  if (waitTime > 0) {
+    await new Promise(resolve => setTimeout(resolve, waitTime));
+  }
+  lastCall = Date.now();
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "incremental": true
   }
 }


### PR DESCRIPTION
## Summary
- add axios based clients for Performance and Seller APIs with rate limiting and token refresh
- expose environment-based configuration for API credentials
- support `@/*` path alias

## Testing
- `npm test` *(fails: bash: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c41325a688832a93d6fab91f941201