### PR TITLE
feat: add centralized configuration constants

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,10 +4,17 @@ import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
 import { TransactionModule } from './transaction/transaction.module';
 import { OrderModule } from './order/order.module';
+import { APP_CONSTANTS } from './config/constants';
 
 @Module({
   imports: [PrismaModule, TransactionModule, OrderModule],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: 'APP_CONSTANTS',
+      useValue: APP_CONSTANTS,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,26 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+function loadEnv() {
+  const envPath = path.resolve(process.cwd(), '.env');
+  if (fs.existsSync(envPath)) {
+    const lines = fs.readFileSync(envPath, 'utf-8').split(/\r?\n/);
+    for (const line of lines) {
+      const match = line.match(/^\s*([A-Za-z_][\w]*)\s*=\s*(.*)?\s*$/);
+      if (match) {
+        const [, key, value] = match;
+        if (process.env[key] === undefined) {
+          process.env[key] = value;
+        }
+      }
+    }
+  }
+}
+
+loadEnv();
+
+export const APP_CONSTANTS = {
+  PORT: parseInt(process.env.PORT ?? '3000', 10),
+};
+
+export type AppConstants = typeof APP_CONSTANTS;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { APP_CONSTANTS } from './config/constants';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  await app.listen(APP_CONSTANTS.PORT);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- add configuration constants module for app settings
- provide constants in AppModule and use port constant when bootstrapping
- load `.env` file to populate configuration from environment variables

## Testing
- `npm test` *(fails: SyntaxError in app.controller.spec.ts - Missing semicolon)*

------
https://chatgpt.com/codex/tasks/task_e_68c4146dbb50832aba834317553b4442