### PR TITLE
feat: add seller postings retrieval

### DIFF
--- a/src/api/seller/dto/get-postings.dto.ts
+++ b/src/api/seller/dto/get-postings.dto.ts
@@ -1,0 +1,4 @@
+export class GetPostingsDto {
+  limit?: number;
+  offset?: number;
+}

--- a/src/api/seller/posting.service.ts
+++ b/src/api/seller/posting.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@nestjs/common";
+import { SellerApiService } from "./seller.service";
+import { GetPostingsDto } from "./dto/get-postings.dto";
+
+@Injectable()
+export class PostingApiService {
+  constructor(private readonly sellerApi: SellerApiService) {}
+
+  async list(data: GetPostingsDto) {
+    const { data: response } = await this.sellerApi.client.axiosRef.post(
+      "/v3/posting/fbs/list",
+      data,
+    );
+    return response;
+  }
+}

--- a/src/api/seller/seller.module.ts
+++ b/src/api/seller/seller.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { HttpModule } from "@nestjs/axios";
 import { SellerApiService } from "./seller.service";
+import { PostingApiService } from "./posting.service";
 import { SELLER_CLIENT_ID, SELLER_API_KEY, OZON_SELLER_API_URL } from "@/config";
 
 @Module({
@@ -14,8 +15,8 @@ import { SELLER_CLIENT_ID, SELLER_API_KEY, OZON_SELLER_API_URL } from "@/config"
       },
     }),
   ],
-  providers: [SellerApiService],
-  exports: [SellerApiService],
+  providers: [SellerApiService, PostingApiService],
+  exports: [SellerApiService, PostingApiService],
 })
 export class SellerApiModule {}
 


### PR DESCRIPTION
## Summary
- expose Posting API service for listing postings from Ozon seller API
- wire PostingApiService into SellerApiModule

## Testing
- `npm test` *(fails: Jest failed to parse TypeScript spec)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@nestjs/axios')*


------
https://chatgpt.com/codex/tasks/task_e_68c42fdb3bf8832a933c24b9df139a7b