### PR TITLE
feat: save postings via order module

### DIFF
--- a/src/modules/order/order.controller.ts
+++ b/src/modules/order/order.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/commo
 import { OrderService } from './order.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { UpdateOrderDto } from './dto/update-order.dto';
+import { GetPostingsDto } from '@/api/seller/dto/get-postings.dto';
 
 @Controller('orders')
 export class OrderController {
@@ -10,6 +11,11 @@ export class OrderController {
   @Post()
   create(@Body() dto: CreateOrderDto) {
     return this.orderService.create(dto);
+  }
+
+  @Post('postings')
+  savePostings(@Body() dto: GetPostingsDto) {
+    return this.orderService.savePostings(dto);
   }
 
   @Get()

--- a/src/modules/order/order.module.ts
+++ b/src/modules/order/order.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { OrderService } from './order.service';
 import { OrderController } from './order.controller';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { SellerApiModule } from '@/api/seller/seller.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, SellerApiModule],
   controllers: [OrderController],
   providers: [OrderService],
 })

--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -2,10 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { UpdateOrderDto } from './dto/update-order.dto';
+import { GetPostingsDto } from '@/api/seller/dto/get-postings.dto';
+import { PostingApiService } from '@/api/seller/posting.service';
 
 @Injectable()
 export class OrderService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly postingApi: PostingApiService,
+  ) {}
 
   create(data: CreateOrderDto) {
     return this.prisma.order.create({ data });
@@ -25,5 +30,47 @@ export class OrderService {
 
   remove(id: string) {
     return this.prisma.order.delete({ where: { id } });
+  }
+
+  async savePostings(dto: GetPostingsDto) {
+    const { result } = await this.postingApi.list(dto);
+    const postings = result?.postings ?? [];
+
+    const operations = postings.map((posting: any) => {
+      const product = posting.products?.[0] ?? {};
+      const analytics = posting.analytics_data ?? {};
+      const financial = posting.financial_data?.products?.[0] ?? {};
+
+      const data: CreateOrderDto = {
+        product: product.name ?? '',
+        orderId: String(posting.order_id ?? ''),
+        orderNumber: posting.order_number ?? '',
+        postingNumber: posting.posting_number ?? '',
+        status: posting.status ?? '',
+        createdAt: new Date(posting.created_at ?? Date.now()),
+        inProcessAt: new Date(posting.in_process_at ?? Date.now()),
+        deliveryType: analytics.delivery_type ?? '',
+        city: analytics.city ?? undefined,
+        isPremium: analytics.is_premium ?? false,
+        paymentTypeGroupName: analytics.payment_type_group_name ?? '',
+        warehouseId: String(analytics.warehouse_id ?? ''),
+        warehouseName: analytics.warehouse_name ?? '',
+        sku: String(product.sku ?? ''),
+        oldPrice: Number(financial.old_price ?? product.old_price ?? 0),
+        price: Number(financial.price ?? product.price ?? 0),
+        currencyCode: financial.currency_code ?? 'RUB',
+        clusterFrom: analytics.cluster_from ?? '',
+        clusterTo: analytics.cluster_to ?? '',
+      };
+
+      return this.prisma.order.upsert({
+        where: { postingNumber: data.postingNumber },
+        create: data,
+        update: data,
+      });
+    });
+
+    await this.prisma.$transaction(operations);
+    return postings.length;
   }
 }


### PR DESCRIPTION
## Summary
- add Posting API integration to order module
- persist postings returned by Seller API into orders table
- expose endpoint to trigger postings save

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in app.controller.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c43227a494832a8f006e08f0b8ce57