### PR TITLE
feat(order): update undelivered postings

### DIFF
--- a/src/modules/order/order.controller.ts
+++ b/src/modules/order/order.controller.ts
@@ -10,4 +10,9 @@ export class OrderController {
   savePostings(@Query() dto: GetPostingsDto) {
     return this.orderService.saveOrders(dto);
   }
+
+  @Get('sync-pending')
+  updatePending() {
+    return this.orderService.updateNotDelivered();
+  }
 }


### PR DESCRIPTION
## Summary
- add OrderService.updateNotDelivered to refresh postings from last pending order date to today
- expose GET /orders/sync-pending endpoint to trigger pending postings refresh

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c481a09150832abe5fd2d7e6bf8038