### PR TITLE
feat: combine save and pending sync

### DIFF
--- a/src/modules/order/order.controller.ts
+++ b/src/modules/order/order.controller.ts
@@ -7,12 +7,7 @@ export class OrderController {
   constructor(private readonly orderService: OrderService) {}
 
   @Get('sync')
-  savePostings(@Query() dto: GetPostingsDto) {
-    return this.orderService.saveOrders(dto);
-  }
-
-  @Get('sync-pending')
-  updatePending() {
-    return this.orderService.updateNotDelivered();
+  sync(@Query() dto: GetPostingsDto) {
+    return this.orderService.sync(dto);
   }
 }

--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -12,6 +12,14 @@ export class OrderService {
     ) {
     }
 
+    async sync(dto: GetPostingsDto) {
+        const ordersCount = await this.prisma.order.count();
+        if (ordersCount === 0) {
+            return this.saveOrders(dto);
+        }
+        return this.updateNotDelivered();
+    }
+
     async saveOrders(dto: GetPostingsDto) {
         const result = await this.postingApi.list(dto);
         const postings = result ?? [];


### PR DESCRIPTION
## Summary
- add sync logic to choose between full posting save and pending updates
- expose unified `sync` endpoint in order controller

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c482ec46a0832a8baeadf32e241c9d