### PR TITLE
feat: sync transactions from Ozon API

### DIFF
--- a/src/api/seller/dto/get-transactions.dto.ts
+++ b/src/api/seller/dto/get-transactions.dto.ts
@@ -1,0 +1,23 @@
+import {Type} from 'class-transformer';
+import {IsDateString, IsOptional, ValidateNested} from 'class-validator';
+
+class DateFilterDto {
+  @IsDateString()
+  from: string;
+
+  @IsDateString()
+  to: string;
+}
+
+class FilterDto {
+  @ValidateNested()
+  @Type(() => DateFilterDto)
+  date: DateFilterDto;
+}
+
+export class GetTransactionsDto {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => FilterDto)
+  filter?: FilterDto;
+}

--- a/src/api/seller/seller.module.ts
+++ b/src/api/seller/seller.module.ts
@@ -2,6 +2,7 @@ import {Module} from "@nestjs/common";
 import {HttpModule} from "@nestjs/axios";
 import {SellerApiService} from "./seller.service";
 import {PostingApiService} from "./posting.service";
+import {TransactionApiService} from "./transaction.service";
 
 @Module({
     imports: [
@@ -14,8 +15,8 @@ import {PostingApiService} from "./posting.service";
             },
         }),
     ],
-    providers: [SellerApiService, PostingApiService],
-    exports: [SellerApiService, PostingApiService],
+    providers: [SellerApiService, PostingApiService, TransactionApiService],
+    exports: [SellerApiService, PostingApiService, TransactionApiService],
 })
 export class SellerApiModule {
 }

--- a/src/api/seller/transaction.service.ts
+++ b/src/api/seller/transaction.service.ts
@@ -1,0 +1,32 @@
+import {Injectable} from "@nestjs/common";
+import {SellerApiService} from "./seller.service";
+import {GetTransactionsDto} from "./dto/get-transactions.dto";
+
+@Injectable()
+export class TransactionApiService {
+    constructor(private readonly sellerApi: SellerApiService) {}
+
+    async list(data: GetTransactionsDto) {
+        let page = 1;
+        const page_size = 1000;
+        const transactions: any[] = [];
+
+        while (true) {
+            const {data: response} = await this.sellerApi.client.axiosRef.post(
+                "/v3/finance/transaction/list",
+                {...data, page, page_size},
+            );
+
+            const batch = response?.result?.operations ?? response?.result ?? [];
+            transactions.push(...batch);
+
+            if (batch.length < page_size) {
+                break;
+            }
+
+            page += 1;
+        }
+
+        return transactions;
+    }
+}

--- a/src/modules/transaction/transaction.controller.ts
+++ b/src/modules/transaction/transaction.controller.ts
@@ -12,6 +12,11 @@ export class TransactionController {
     return this.transactionService.create(dto);
   }
 
+  @Get('sync')
+  sync() {
+    return this.transactionService.sync();
+  }
+
   @Get()
   findAll() {
     return this.transactionService.findAll();

--- a/src/modules/transaction/transaction.module.ts
+++ b/src/modules/transaction/transaction.module.ts
@@ -3,9 +3,10 @@ import { TransactionService } from './transaction.service';
 import { TransactionController } from './transaction.controller';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { TransactionRepository } from './transaction.repository';
+import { SellerApiModule } from '@/api/seller/seller.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, SellerApiModule],
   controllers: [TransactionController],
   providers: [TransactionService, TransactionRepository],
 })

--- a/src/modules/transaction/transaction.repository.ts
+++ b/src/modules/transaction/transaction.repository.ts
@@ -2,10 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { Prisma, Transaction } from '@prisma/client';
 
 @Injectable()
 export class TransactionRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  count() {
+    return this.prisma.transaction.count();
+  }
 
   create(data: CreateTransactionDto) {
     return this.prisma.transaction.create({ data });
@@ -19,11 +24,19 @@ export class TransactionRepository {
     return this.prisma.transaction.findUnique({ where: { id } });
   }
 
+  findLast(): Promise<Transaction | null> {
+    return this.prisma.transaction.findFirst({ orderBy: { date: 'desc' } });
+  }
+
   update(id: string, data: UpdateTransactionDto) {
     return this.prisma.transaction.update({ where: { id }, data });
   }
 
   remove(id: string) {
     return this.prisma.transaction.delete({ where: { id } });
+  }
+
+  transaction<T>(operations: Prisma.PrismaPromise<T>[]) {
+    return this.prisma.$transaction(operations);
   }
 }

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -2,10 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
 import { UpdateTransactionDto } from './dto/update-transaction.dto';
 import { TransactionRepository } from './transaction.repository';
+import { TransactionApiService } from '@/api/seller/transaction.service';
 
 @Injectable()
 export class TransactionService {
-  constructor(private readonly repository: TransactionRepository) {}
+  constructor(
+    private readonly repository: TransactionRepository,
+    private readonly transactionApi: TransactionApiService,
+  ) {}
 
   create(data: CreateTransactionDto) {
     return this.repository.create(data);
@@ -25,5 +29,75 @@ export class TransactionService {
 
   remove(id: string) {
     return this.repository.remove(id);
+  }
+
+  async sync() {
+    const count = await this.repository.count();
+    const last = count === 0 ? null : await this.repository.findLast();
+    let from = last?.date ?? new Date('2024-10-01T00:00:00.000Z');
+    const now = new Date();
+    let total = 0;
+
+    while (from < now) {
+      const to = new Date(from);
+      to.setMonth(to.getMonth() + 1);
+      if (to > now) {
+        to.setTime(now.getTime());
+      }
+
+      const transactions = await this.transactionApi.list({
+        filter: {
+          date: {
+            from: from.toISOString(),
+            to: to.toISOString(),
+          },
+        },
+      });
+
+      if (transactions.length) {
+        const operations = transactions.flatMap((t: any) => {
+          const base: CreateTransactionDto = {
+            operationType: t.operation_type ?? '',
+            operationTypeName: t.operation_type_name ?? '',
+            operationServiceName: t.operation_service_name ?? '',
+            date: new Date(t.transaction_date ?? t.date ?? Date.now()),
+            type: t.type ?? '',
+            postingNumber: t.posting_number ?? '',
+            price: Number(t.price ?? t.amount ?? 0),
+          };
+
+          const ops: any[] = [this.repository.create(base)];
+
+          const services = Array.isArray(t.services) ? t.services : [];
+          for (const s of services) {
+            const serviceData: CreateTransactionDto = {
+              ...base,
+              operationServiceName: s.name ?? '',
+              price: Number(s.price ?? 0),
+            };
+            ops.push(this.repository.create(serviceData));
+          }
+
+          const saleCommission = Number(t.sale_commission ?? 0);
+          if (saleCommission !== 0) {
+            const commissionData: CreateTransactionDto = {
+              ...base,
+              operationServiceName: 'sale_commission',
+              price: saleCommission,
+            };
+            ops.push(this.repository.create(commissionData));
+          }
+
+          return ops;
+        });
+
+        await this.repository.transaction(operations as any);
+        total += operations.length;
+      }
+
+      from = to;
+    }
+
+    return total;
   }
 }


### PR DESCRIPTION
## Summary
- fetch Ozon transactions with page-based pagination
- sync transactions to database month by month from last record
- store individual service charges and sale commissions from each transaction
- perform pagination entirely inside transaction API client

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@nestjs/axios)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4863261f8832a9299aa1ed22d53e4