### PR TITLE
feat: aggregate orders with transactions

### DIFF
--- a/src/modules/order/order.controller.ts
+++ b/src/modules/order/order.controller.ts
@@ -6,6 +6,11 @@ import { GetPostingsDto } from '@/api/seller/dto/get-postings.dto';
 export class OrderController {
   constructor(private readonly orderService: OrderService) {}
 
+  @Get()
+  aggregate() {
+    return this.orderService.aggregate();
+  }
+
   @Get('sync')
   sync(@Query() dto: GetPostingsDto) {
     return this.orderService.sync(dto);

--- a/src/modules/order/order.module.ts
+++ b/src/modules/order/order.module.ts
@@ -4,10 +4,11 @@ import { OrderController } from './order.controller';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { SellerApiModule } from '@/api/seller/seller.module';
 import { OrderRepository } from './order.repository';
+import { TransactionRepository } from '@/modules/transaction/transaction.repository';
 
 @Module({
   imports: [PrismaModule, SellerApiModule],
   controllers: [OrderController],
-  providers: [OrderService, OrderRepository],
+  providers: [OrderService, OrderRepository, TransactionRepository],
 })
 export class OrderModule {}

--- a/src/modules/order/order.repository.ts
+++ b/src/modules/order/order.repository.ts
@@ -11,6 +11,10 @@ export class OrderRepository {
     return this.prisma.order.count();
   }
 
+  findAll(): Promise<Order[]> {
+    return this.prisma.order.findMany();
+  }
+
   upsert(data: CreateOrderDto): Promise<Order> {
     return this.prisma.order.upsert({
       where: { postingNumber: data.postingNumber },

--- a/src/modules/transaction/transaction.repository.ts
+++ b/src/modules/transaction/transaction.repository.ts
@@ -20,6 +20,13 @@ export class TransactionRepository {
     return this.prisma.transaction.findMany();
   }
 
+  groupByPostingNumber() {
+    return this.prisma.transaction.groupBy({
+      by: ['postingNumber'],
+      _sum: { price: true },
+    });
+  }
+
   findById(id: string) {
     return this.prisma.transaction.findUnique({ where: { id } });
   }


### PR DESCRIPTION
## Summary
- add endpoint to return orders with summed transaction totals
- track transaction sums via repository groupBy

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching @nestjs/axios)*

------
https://chatgpt.com/codex/tasks/task_e_68c48a76ae04832a9588988e02d4b6e8