### PR TITLE
feat: deduplicate transactions using composite unique key

### DIFF
--- a/prisma/migrations/20240913201000_add_transaction_unique/migration.sql
+++ b/prisma/migrations/20240913201000_add_transaction_unique/migration.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "Transaction_operationServiceName_postingNumber_key" ON "Transaction"("operationServiceName", "postingNumber");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,8 @@ model Transaction {
   type                 String
   postingNumber        String
   price                Int
+
+  @@unique([operationServiceName, postingNumber])
 }
 
 model Order {

--- a/src/modules/transaction/transaction.repository.ts
+++ b/src/modules/transaction/transaction.repository.ts
@@ -13,7 +13,16 @@ export class TransactionRepository {
   }
 
   create(data: CreateTransactionDto) {
-    return this.prisma.transaction.create({ data });
+    return this.prisma.transaction.upsert({
+      where: {
+        operationServiceName_postingNumber: {
+          operationServiceName: data.operationServiceName,
+          postingNumber: data.postingNumber,
+        },
+      },
+      create: data,
+      update: data,
+    });
   }
 
   findAll() {


### PR DESCRIPTION
## Summary
- add unique constraint for Transaction on operationServiceName and postingNumber
- replace create with upsert to avoid duplicate records
- add migration for new unique index

## Testing
- `npx prisma migrate dev --name transaction_unique` *(fails: 403 Forbidden - cannot access npm registry)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cee9c308832a82461222673d263f