### PR TITLE
Store transaction price with cents

### DIFF
--- a/prisma/migrations/20240913212000_transaction_price_float/migration.sql
+++ b/prisma/migrations/20240913212000_transaction_price_float/migration.sql
@@ -1,0 +1,24 @@
+-- Alter Transaction.price from Int to Float
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "Transaction_new" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "operationType" TEXT NOT NULL,
+  "operationTypeName" TEXT NOT NULL,
+  "operationServiceName" TEXT NOT NULL,
+  "date" DATETIME NOT NULL,
+  "type" TEXT NOT NULL,
+  "postingNumber" TEXT NOT NULL,
+  "price" REAL NOT NULL
+);
+
+INSERT INTO "Transaction_new" ("id", "operationType", "operationTypeName", "operationServiceName", "date", "type", "postingNumber", "price")
+SELECT "id", "operationType", "operationTypeName", "operationServiceName", "date", "type", "postingNumber", "price"
+FROM "Transaction";
+
+DROP TABLE "Transaction";
+ALTER TABLE "Transaction_new" RENAME TO "Transaction";
+
+CREATE UNIQUE INDEX "Transaction_operationServiceName_postingNumber_key" ON "Transaction"("operationServiceName", "postingNumber");
+
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model Transaction {
   date                 DateTime
   type                 String
   postingNumber        String
-  price                Int
+  price                Float
 
   @@unique([operationServiceName, postingNumber])
 }


### PR DESCRIPTION
## Summary
- use floating-point price field for transactions
- migrate existing Transaction table to maintain values

## Testing
- ⚠️ `npm test` *(jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dcb91e70832a9915ef8185c7543c