### PR TITLE
Add filtering options to order aggregation

### DIFF
--- a/src/modules/order/dto/aggregate-order.dto.ts
+++ b/src/modules/order/dto/aggregate-order.dto.ts
@@ -1,0 +1,19 @@
+import { IsDateString, IsOptional, IsString } from 'class-validator';
+
+export class AggregateOrderDto {
+  @IsOptional()
+  @IsString()
+  postingNumber?: string;
+
+  @IsOptional()
+  @IsDateString()
+  createdAt?: string;
+
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @IsOptional()
+  @IsString()
+  sku?: string;
+}

--- a/src/modules/order/order.controller.ts
+++ b/src/modules/order/order.controller.ts
@@ -1,14 +1,15 @@
 import { Query, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
 import { OrderService } from './order.service';
 import { GetPostingsDto } from '@/api/seller/dto/get-postings.dto';
+import { AggregateOrderDto } from './dto/aggregate-order.dto';
 
 @Controller('orders')
 export class OrderController {
   constructor(private readonly orderService: OrderService) {}
 
   @Get()
-  aggregate() {
-    return this.orderService.aggregate();
+  aggregate(@Query() dto: AggregateOrderDto) {
+    return this.orderService.aggregate(dto);
   }
 
   @Get('sync')

--- a/src/modules/order/order.repository.ts
+++ b/src/modules/order/order.repository.ts
@@ -11,8 +11,8 @@ export class OrderRepository {
     return this.prisma.order.count();
   }
 
-  findAll(): Promise<Order[]> {
-    return this.prisma.order.findMany();
+  findAll(where: Prisma.OrderWhereInput = {}): Promise<Order[]> {
+    return this.prisma.order.findMany({ where });
   }
 
   upsert(data: CreateOrderDto): Promise<Order> {

--- a/src/modules/order/order.service.ts
+++ b/src/modules/order/order.service.ts
@@ -4,8 +4,9 @@ import { GetPostingsDto } from "@/api/seller/dto/get-postings.dto";
 import { PostingApiService } from "@/api/seller/posting.service";
 import { OrderRepository } from "./order.repository";
 import { TransactionRepository } from "@/modules/transaction/transaction.repository";
-import { Order, Transaction } from "@prisma/client";
+import { Order, Transaction, Prisma } from "@prisma/client";
 import { economy } from "./economy";
+import { AggregateOrderDto } from "./dto/aggregate-order.dto";
 
 @Injectable()
 export class OrderService {
@@ -85,7 +86,7 @@ export class OrderService {
     }, new Map<string, Transaction[]>());
   }
 
-  async aggregate(): Promise<
+  async aggregate(dto: AggregateOrderDto): Promise<
     (
       Order & {
         transactionTotal: number;
@@ -96,8 +97,22 @@ export class OrderService {
       }
     )[]
   > {
+    const where: Prisma.OrderWhereInput = {};
+    if (dto.postingNumber) {
+      where.postingNumber = dto.postingNumber;
+    }
+    if (dto.status) {
+      where.status = dto.status;
+    }
+    if (dto.sku) {
+      where.sku = dto.sku;
+    }
+    if (dto.createdAt) {
+      where.createdAt = new Date(dto.createdAt);
+    }
+
     const [orders, transactions] = await Promise.all([
-      this.orderRepository.findAll(),
+      this.orderRepository.findAll(where),
       this.transactionRepository.findAll(),
     ]);
 


### PR DESCRIPTION
## Summary
- allow filtering order aggregation by posting number, date, status and SKU

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: nest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@nestjs%2faxios)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e3a015c8832aa7388999d831ca27