### PR TITLE
feat(order): add totals aggregation and date range filter

### DIFF
--- a/src/modules/order/dto/aggregate-order.dto.ts
+++ b/src/modules/order/dto/aggregate-order.dto.ts
@@ -7,7 +7,11 @@ export class AggregateOrderDto {
 
   @IsOptional()
   @IsDateString()
-  createdAt?: string;
+  from?: string;
+
+  @IsOptional()
+  @IsDateString()
+  to?: string;
 
   @IsOptional()
   @IsString()


### PR DESCRIPTION
## Summary
- extend order aggregation to include items and totals with statuses and sums
- allow filtering by createdAt date range using `from` and `to` without time

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@nestjs%2faxios)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e597b308832aa9155fb472514f23