### PR TITLE
refactor: move transaction sync loop into api service

### DIFF
--- a/src/api/seller/transaction.service.ts
+++ b/src/api/seller/transaction.service.ts
@@ -1,12 +1,51 @@
 import {Injectable} from "@nestjs/common";
 import {SellerApiService} from "./seller.service";
 import {GetTransactionsDto} from "./dto/get-transactions.dto";
+import * as dayjs from 'dayjs';
 
 @Injectable()
 export class TransactionApiService {
     constructor(private readonly sellerApi: SellerApiService) {}
 
     async list(data: GetTransactionsDto) {
+        const transactions: any[] = [];
+
+        const from = data?.filter?.date?.from ? new Date(data.filter.date.from) : null;
+        const to = data?.filter?.date?.to ? new Date(data.filter.date.to) : null;
+
+        if (from && to) {
+            let cursor = from;
+
+            while (cursor < to) {
+                let end = dayjs(cursor).add(1, 'month').toDate();
+                if (end > to) {
+                    end = to;
+                }
+
+                const batch = await this.listMonth({
+                    ...data,
+                    filter: {
+                        ...(data.filter ?? {}),
+                        date: {
+                            from: cursor.toISOString(),
+                            to: end.toISOString(),
+                        },
+                    },
+                });
+
+                transactions.push(...batch);
+
+                cursor = dayjs(end).add(1, 'day').toDate();
+            }
+        } else {
+            const batch = await this.listMonth(data);
+            transactions.push(...batch);
+        }
+
+        return transactions;
+    }
+
+    private async listMonth(data: GetTransactionsDto) {
         let page = 1;
         const page_size = 1000;
         const transactions: any[] = [];


### PR DESCRIPTION
## Summary
- simplify transaction sync by delegating date iteration to API layer
- handle monthly fetches within TransactionApiService

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c600632e0c832ab35e96343961a806