### PR TITLE
refactor: improve unit filters

### DIFF
--- a/src/modules/unit/utils/order-filter.utils.ts
+++ b/src/modules/unit/utils/order-filter.utils.ts
@@ -1,0 +1,48 @@
+import { Prisma } from '@prisma/client';
+import { AggregateUnitDto } from '../dto/aggregate-unit.dto';
+
+const DIRECT_FILTERS: (keyof AggregateUnitDto)[] = ['postingNumber', 'sku'];
+
+export const buildOrderWhere = (
+  dto: AggregateUnitDto,
+): Prisma.OrderWhereInput => {
+  const where = DIRECT_FILTERS.reduce((acc, key) => {
+    const value = dto[key];
+    if (value !== undefined) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {} as Prisma.OrderWhereInput);
+
+  const createdAt = buildCreatedAtFilter(dto.from, dto.to);
+  if (createdAt) {
+    where.createdAt = createdAt;
+  }
+
+  return where;
+};
+
+export const buildCreatedAtFilter = (
+  from?: string,
+  to?: string,
+): Prisma.DateTimeFilter | undefined => {
+  if (!from && !to) {
+    return undefined;
+  }
+
+  const filter: Prisma.DateTimeFilter = {};
+
+  if (from) {
+    const fromDate = new Date(from);
+    fromDate.setHours(0, 0, 0, 0);
+    filter.gte = fromDate;
+  }
+
+  if (to) {
+    const toDate = new Date(to);
+    toDate.setHours(23, 59, 59, 999);
+    filter.lte = toDate;
+  }
+
+  return filter;
+};


### PR DESCRIPTION
## Summary
- add reusable filter builder for unit queries
- support multi-status filtering and centralize order filter logic

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@nestjs%2faxios)*

------
https://chatgpt.com/codex/tasks/task_e_68c693a20cfc832abe329c531d56079f