### PR TITLE
refactor transaction api and service

### DIFF
--- a/src/api/seller/transaction.service.ts
+++ b/src/api/seller/transaction.service.ts
@@ -3,6 +3,7 @@ import { SellerApiService } from "./seller.service";
 import { GetTransactionsDto } from "./dto/get-transactions.dto";
 import dayjs from "dayjs";
 import { TransactionEntity } from "@/modules/transaction/entities/transaction.entity";
+import { ADS_EXCLUDED_OPERATION_TYPES } from "@/shared/constants/transaction-types.constants";
 
 interface DateRange {
   from: Date;
@@ -75,7 +76,12 @@ export class TransactionApiService {
     const baseDate = dayjs(t.operation_date, "YYYY-MM-DD HH:mm:ss").toDate();
     const results: TransactionEntity[] = [];
 
-    if (Array.isArray(t.services) && t.services.length) {
+    const isAds =
+      Array.isArray(t.services) &&
+      t.services.length &&
+      !ADS_EXCLUDED_OPERATION_TYPES.has(t.operation_type);
+
+    if (isAds) {
       for (const s of t.services) {
         results.push(
           new TransactionEntity({

--- a/src/api/seller/transaction.service.ts
+++ b/src/api/seller/transaction.service.ts
@@ -73,13 +73,14 @@ export class TransactionApiService {
   }
 
   private normalize(t: any): TransactionEntity[] {
+    if (ADS_EXCLUDED_OPERATION_TYPES.has(t.operation_type)) {
+      return [];
+    }
+
     const baseDate = dayjs(t.operation_date, "YYYY-MM-DD HH:mm:ss").toDate();
     const results: TransactionEntity[] = [];
 
-    const isAds =
-      Array.isArray(t.services) &&
-      t.services.length &&
-      !ADS_EXCLUDED_OPERATION_TYPES.has(t.operation_type);
+    const isAds = Array.isArray(t.services) && t.services.length;
 
     if (isAds) {
       for (const s of t.services) {

--- a/src/api/seller/transaction.service.ts
+++ b/src/api/seller/transaction.service.ts
@@ -1,111 +1,145 @@
-import {Injectable} from "@nestjs/common";
-import {SellerApiService} from "./seller.service";
-import {GetTransactionsDto} from "./dto/get-transactions.dto";
-import dayjs from 'dayjs';
-import {TransactionEntity} from "@/modules/transaction/entities/transaction.entity";
+import { Injectable } from "@nestjs/common";
+import { SellerApiService } from "./seller.service";
+import { GetTransactionsDto } from "./dto/get-transactions.dto";
+import dayjs from "dayjs";
+import { TransactionEntity } from "@/modules/transaction/entities/transaction.entity";
+
+interface DateRange {
+  from: Date;
+  to: Date;
+}
 
 @Injectable()
 export class TransactionApiService {
-    constructor(private readonly sellerApi: SellerApiService) {
+  constructor(private readonly sellerApi: SellerApiService) {}
+
+  async list(data: GetTransactionsDto): Promise<TransactionEntity[]> {
+    const ranges = this.buildRanges(data);
+    const transactions: TransactionEntity[] = [];
+
+    if (ranges.length === 0) {
+      const batch = await this.fetchMonth(data);
+      for (const t of batch) {
+        transactions.push(...this.normalize(t));
+      }
+      return transactions;
     }
 
-    async list(data: GetTransactionsDto) {
-        const transactions: any[] = [];
+    for (const range of ranges) {
+      const batch = await this.fetchMonth({
+        ...data,
+        filter: {
+          ...(data.filter ?? {}),
+          date: {
+            from: range.from.toISOString(),
+            to: range.to.toISOString(),
+          },
+        },
+      });
 
-        const from = data?.filter?.date?.from ? new Date(data.filter.date.from) : null;
-        const to = data?.filter?.date?.to ? new Date(data.filter.date.to) : null;
+      for (const t of batch) {
+        transactions.push(...this.normalize(t));
+      }
+    }
 
-        if (from && to) {
-            let cursor = from;
+    return transactions;
+  }
 
-            while (cursor < to) {
-                let end = dayjs(cursor).add(1, 'month').toDate();
-                if (end > to) {
-                    end = to;
-                }
+  private buildRanges(data: GetTransactionsDto): DateRange[] {
+    const from = data?.filter?.date?.from
+      ? new Date(data.filter.date.from)
+      : null;
+    const to = data?.filter?.date?.to ? new Date(data.filter.date.to) : null;
 
-                const batch = await this.listMonth({
-                    ...data,
-                    filter: {
-                        ...(data.filter ?? {}),
-                        date: {
-                            from: cursor.toISOString(),
-                            to: end.toISOString(),
-                        },
-                    },
-                });
+    if (!from || !to) {
+      return [];
+    }
 
-                for (const t of batch) {
-                    for (const s of t.services) {
-                        if (s.length !== 0) {
-                            transactions.push({
-                                operationId: String(t.operation_id ?? ''),
-                                name: s.name ?? '',
-                                date: dayjs(t.operation_date, 'YYYY-MM-DD HH:mm:ss').toDate(),
-                                postingNumber: t.posting?.posting_number,
-                                price: Number(s.price ?? 0),
-                            })
-                        } else {
-                            transactions.push({
-                                operationId: String(t.operation_id ?? ''),
-                                name: t.operation_type,
-                                date: dayjs(t.operation_date, 'YYYY-MM-DD HH:mm:ss').toDate(),
-                                postingNumber: t.posting?.posting_number,
-                                price: Number(t.amount ?? 0),
-                            })
-                        }
-                    }
+    const ranges: DateRange[] = [];
+    let cursor = from;
 
-                    const saleCommission = Number(t.sale_commission ?? 0);
+    while (cursor < to) {
+      let end = dayjs(cursor).add(1, "month").toDate();
+      if (end > to) {
+        end = to;
+      }
 
-                    if (saleCommission !== 0) {
-                        transactions.push({
-                            operationId: String(t.operation_id ?? ''),
-                            name: 'SaleCommission',
-                            date: dayjs(t.operation_date, 'YYYY-MM-DD HH:mm:ss').toDate(),
-                            postingNumber: t.posting?.posting_number ?? '',
-                            price: saleCommission,
-                        });
-                    }
-                }
+      ranges.push({ from: cursor, to: end });
+      cursor = dayjs(end).add(1, "day").toDate();
+    }
 
-                transactions.push(...batch);
+    return ranges;
+  }
 
-                cursor = dayjs(end).add(1, 'day').toDate();
-            }
-        } else {
-            const batch = await this.listMonth(data);
-            transactions.push(...batch);
+  private normalize(t: any): TransactionEntity[] {
+    const baseDate = dayjs(t.operation_date, "YYYY-MM-DD HH:mm:ss").toDate();
+    const results: TransactionEntity[] = [];
+
+    if (Array.isArray(t.services) && t.services.length) {
+      for (const s of t.services) {
+        results.push(
+          new TransactionEntity({
+            operationId: String(t.operation_id ?? ""),
+            name: s.name ?? "",
+            date: baseDate,
+            postingNumber: t.posting?.posting_number,
+            price: Number(s.price ?? 0),
+          })
+        );
+      }
+    } else {
+      results.push(
+        new TransactionEntity({
+          operationId: String(t.operation_id ?? ""),
+          name: t.operation_type,
+          date: baseDate,
+          postingNumber: t.posting?.posting_number,
+          price: Number(t.amount ?? 0),
+        })
+      );
+    }
+
+    const saleCommission = Number(t.sale_commission ?? 0);
+    if (saleCommission !== 0) {
+      results.push(
+        new TransactionEntity({
+          operationId: String(t.operation_id ?? ""),
+          name: "SaleCommission",
+          date: baseDate,
+          postingNumber: t.posting?.posting_number ?? "",
+          price: saleCommission,
+        })
+      );
+    }
+
+    return results;
+  }
+
+  private async fetchMonth(data: GetTransactionsDto) {
+    let page = 1;
+    const page_size = 1000;
+    const transactions: any[] = [];
+
+    while (true) {
+      const { data: response } = await this.sellerApi.client.axiosRef.post(
+        "/v3/finance/transaction/list",
+        {
+          ...data,
+          page,
+          page_size,
         }
+      );
 
-        return transactions;
+      const batch = response?.result?.operations ?? response?.result ?? [];
+      transactions.push(...batch);
+
+      if (batch.length < page_size) {
+        break;
+      }
+
+      page += 1;
     }
 
-    private async listMonth(data: GetTransactionsDto) {
-        let page = 1;
-        const page_size = 1000;
-        const transactions: any[] = [];
-
-        while (true) {
-            const {data: response} = await this.sellerApi.client.axiosRef.post(
-                "/v3/finance/transaction/list",
-                {
-                    ...data,
-                    page,
-                    page_size
-                },
-            );
-
-            const batch = response?.result?.operations ?? response?.result ?? [];
-            transactions.push(...batch);
-
-            if (batch.length < page_size) {
-                break;
-            }
-
-            page += 1;
-        }
-
-        return transactions;
-    }
+    return transactions;
+  }
 }

--- a/src/modules/transaction/transaction.controller.ts
+++ b/src/modules/transaction/transaction.controller.ts
@@ -1,7 +1,5 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { TransactionService } from './transaction.service';
-import { CreateTransactionDto } from './dto/create-transaction.dto';
-import { UpdateTransactionDto } from './dto/update-transaction.dto';
 
 @Controller('transactions')
 export class TransactionController {

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { TransactionRepository } from './transaction.repository';
 import { TransactionApiService } from '@/api/seller/transaction.service';
+import { ADS_EXCLUDED_OPERATION_TYPES } from '@/shared/constants/transaction-types.constants';
 
 @Injectable()
 export class TransactionService {
@@ -26,12 +27,16 @@ export class TransactionService {
       },
     });
 
-    if (!operations.length) {
+    const filtered = operations.filter(
+      (op) => !ADS_EXCLUDED_OPERATION_TYPES.has(op.name),
+    );
+
+    if (!filtered.length) {
       return 0;
     }
 
-    const queries = operations.map((op) => this.repository.create(op));
+    const queries = filtered.map((op) => this.repository.create(op));
     await this.repository.transaction(queries);
-    return operations.length;
+    return filtered.length;
   }
 }

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -1,60 +1,37 @@
-import {Injectable} from '@nestjs/common';
-import {TransactionRepository} from './transaction.repository';
-import {TransactionApiService} from '@/api/seller/transaction.service';
-import {TransactionEntity} from './entities/transaction.entity';
-import dayjs from "dayjs";
-import {TRANSACTION_TYPES_ADS} from "@/shared/constants/transaction-types.constants";
+import { Injectable } from '@nestjs/common';
+import { TransactionRepository } from './transaction.repository';
+import { TransactionApiService } from '@/api/seller/transaction.service';
 
 @Injectable()
 export class TransactionService {
-    constructor(
-        private readonly repository: TransactionRepository,
-        private readonly transactionApi: TransactionApiService,
-    ) {
+  constructor(
+    private readonly repository: TransactionRepository,
+    private readonly transactionApi: TransactionApiService,
+  ) {}
+
+  async sync() {
+    const count = await this.repository.count();
+    const last = count === 0 ? null : await this.repository.findLast();
+
+    // если нет записей, стартуем с октября 2024
+    const from = last?.date ?? new Date('2024-10-01T00:00:00.000Z');
+    const to = new Date();
+
+    const operations = await this.transactionApi.list({
+      filter: {
+        date: {
+          from: from.toISOString(),
+          to: to.toISOString(),
+        },
+      },
+    });
+
+    if (!operations.length) {
+      return 0;
     }
 
-    async sync() {
-        const count = await this.repository.count();
-        const last = count === 0 ? null : await this.repository.findLast();
-        const operations: TransactionEntity[] = [];
-        let total = 0;
-
-        // если нет записей, стартуем с октября 2024
-        const from = last?.date ?? new Date('2024-10-01T00:00:00.000Z');
-        const to = new Date();
-
-        const transactions = await this.transactionApi.list({
-            filter: {
-                date: {
-                    from: from.toISOString(),
-                    to: to.toISOString(),
-                },
-            },
-        });
-
-        if (transactions.length) {
-            for (const t of transactions) {
-                operations.push(
-                    new TransactionEntity({
-                        operationId: t.operationId,
-                        name: t.name,
-                        date: t.date,
-                        postingNumber: t.postingNumber,
-                        price: t.price,
-                    })
-                )
-            }
-
-            if (operations.length) {
-                const queries = operations.map((op) =>
-                    this.repository.create(op)
-                );
-
-                await this.repository.transaction(queries);
-                total += operations.length;
-            }
-        }
-
-        return total;
-    }
+    const queries = operations.map((op) => this.repository.create(op));
+    await this.repository.transaction(queries);
+    return operations.length;
+  }
 }

--- a/src/shared/constants/transaction-types.constants.ts
+++ b/src/shared/constants/transaction-types.constants.ts
@@ -1,6 +1,6 @@
-export enum TRANSACTION_TYPES_ADS {
-    OperationElectronicServiceStencil,
-    OperationElectronicServicesPromotionInSearch,
-    OperationGettingToTheTop,
-    OperationMarketplaceCostPerClick,
-}
+export const ADS_EXCLUDED_OPERATION_TYPES = new Set<string>([
+  'OperationElectronicServiceStencil',
+  'OperationElectronicServicesPromotionInSearch',
+  'OperationGettingToTheTop',
+  'OperationMarketplaceCostPerClick',
+]);


### PR DESCRIPTION
## Summary
- refactor transaction API to normalize operations and fetch date ranges
- simplify transaction service sync logic
- trim unused code in transaction controller

## Testing
- `npm test` (fails: jest not found)
- `npm install` (fails: 403 Forbidden fetching packages)

------
https://chatgpt.com/codex/tasks/task_e_68c6d86f0e2c832aa72c0f4f5a6ef3ac