### PR TITLE
Add sku column to transactions

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model Transaction {
   date          DateTime
   postingNumber String
   price         Float
+  sku           String   @default("")
 
   @@unique([name, operationId])
 }

--- a/src/api/seller/transaction.service.ts
+++ b/src/api/seller/transaction.service.ts
@@ -79,6 +79,7 @@ export class TransactionApiService {
 
     const baseDate = dayjs(t.operation_date, "YYYY-MM-DD HH:mm:ss").toDate();
     const results: TransactionEntity[] = [];
+    const sku = String(t.items?.[0]?.sku ?? "");
 
     const isAds = Array.isArray(t.services) && t.services.length;
 
@@ -91,6 +92,7 @@ export class TransactionApiService {
             date: baseDate,
             postingNumber: t.posting?.posting_number,
             price: Number(s.price ?? 0),
+            sku,
           })
         );
       }
@@ -102,6 +104,7 @@ export class TransactionApiService {
           date: baseDate,
           postingNumber: t.posting?.posting_number,
           price: Number(t.amount ?? 0),
+          sku,
         })
       );
     }
@@ -115,6 +118,7 @@ export class TransactionApiService {
           date: baseDate,
           postingNumber: t.posting?.posting_number ?? "",
           price: saleCommission,
+          sku,
         })
       );
     }

--- a/src/modules/transaction/dto/create-transaction.dto.ts
+++ b/src/modules/transaction/dto/create-transaction.dto.ts
@@ -4,4 +4,5 @@ export class CreateTransactionDto {
   date: Date;
   postingNumber: string;
   price: number;
+  sku: string;
 }

--- a/src/modules/transaction/entities/transaction.entity.ts
+++ b/src/modules/transaction/entities/transaction.entity.ts
@@ -7,6 +7,7 @@ export class TransactionEntity implements Transaction {
   date: Date;
   postingNumber: string;
   price: number;
+  sku: string;
 
   constructor(partial: Partial<Transaction>) {
     Object.assign(this, partial);


### PR DESCRIPTION
## Summary
- store sku for each transaction by adding sku field to schema and DTOs
- capture item sku when normalizing finance transactions

## Testing
- `npx prisma generate` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@nestjs%2faxios)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e25b2b54832aaef8ba428dfb8c31