### PR TITLE
feat: add finance module

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,8 @@ model Transaction {
   operationId   String
   name          String
   date          DateTime
-  postingNumber String
+  postingNumber String?
+  sku           String?
   price         Float
 
   @@unique([name, operationId])

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import {PrismaModule} from "./prisma/prisma.module";
 import {TransactionModule} from "./modules/transaction/transaction.module";
 import {OrderModule} from "./modules/order/order.module";
 import { UnitModule } from './modules/unit/unit.module';
+import { FinanceModule } from './modules/finance/finance.module';
 import { PerformanceApiModule } from "./api/performance/performance.module";
 import { SellerApiModule } from "./api/seller/seller.module";
 import ozonConfig from "@/config/ozon.config";
@@ -21,6 +22,7 @@ import ozonConfig from "@/config/ozon.config";
         TransactionModule,
         OrderModule,
         UnitModule,
+        FinanceModule,
         PerformanceApiModule,
         SellerApiModule,
     ],

--- a/src/modules/finance/finance.controller.ts
+++ b/src/modules/finance/finance.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { FinanceService } from './finance.service';
+import { FinanceAggregate } from './finance.types';
+
+@Controller('finance')
+export class FinanceController {
+  constructor(private readonly financeService: FinanceService) {}
+
+  @Get()
+  aggregate(): Promise<FinanceAggregate> {
+    return this.financeService.aggregate();
+  }
+}

--- a/src/modules/finance/finance.module.ts
+++ b/src/modules/finance/finance.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { FinanceService } from './finance.service';
+import { FinanceController } from './finance.controller';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { OrderRepository } from '@/modules/order/order.repository';
+import { TransactionRepository } from '@/modules/transaction/transaction.repository';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [FinanceController],
+  providers: [FinanceService, OrderRepository, TransactionRepository],
+})
+export class FinanceModule {}

--- a/src/modules/finance/finance.service.ts
+++ b/src/modules/finance/finance.service.ts
@@ -1,0 +1,164 @@
+import { Injectable } from '@nestjs/common';
+import { OrderRepository } from '@/modules/order/order.repository';
+import { TransactionRepository } from '@/modules/transaction/transaction.repository';
+import { Transaction } from '@prisma/client';
+import dayjs from 'dayjs';
+import { UnitEntity } from '@/modules/unit/entities/unit.entity';
+import {
+  FinanceAggregate,
+  FinanceItem,
+  FinanceMonth,
+} from './finance.types';
+
+@Injectable()
+export class FinanceService {
+  constructor(
+    private readonly orderRepository: OrderRepository,
+    private readonly transactionRepository: TransactionRepository,
+  ) {}
+
+  private groupTransactionsByPostingNumber(
+    transactions: Transaction[],
+  ): Map<string, Transaction[]> {
+    return transactions.reduce((map, tx) => {
+      if (!tx.postingNumber) {
+        return map;
+      }
+      const list = map.get(tx.postingNumber) ?? [];
+      list.push(tx);
+      map.set(tx.postingNumber, list);
+      return map;
+    }, new Map<string, Transaction[]>());
+  }
+
+  async aggregate(): Promise<FinanceAggregate> {
+    const [orders, transactions] = await Promise.all([
+      this.orderRepository.findAll(),
+      this.transactionRepository.findAll(),
+    ]);
+
+    const byPosting = this.groupTransactionsByPostingNumber(transactions);
+
+    const monthMap = new Map<string, Map<string, FinanceItem>>();
+    const monthCounts = new Map<string, number>();
+    const otherMap = new Map<string, Map<string, Record<string, number>>>();
+    const generalMap = new Map<string, Record<string, number>>();
+
+    // build items from orders
+    orders.forEach((order) => {
+      const numbers = [order.postingNumber, order.orderNumber];
+      const txs = numbers.flatMap((n) => byPosting.get(n) ?? []);
+      const uniqueTxs = [...new Map(txs.map((t) => [t.id, t])).values()];
+      const transactionTotal = uniqueTxs.reduce((sum, t) => sum + t.price, 0);
+      const unit = new UnitEntity({
+        ...order,
+        transactionTotal,
+        transactions: uniqueTxs,
+      });
+
+      const month = dayjs(order.createdAt).format('MM-YYYY');
+      const skuMap = monthMap.get(month) ?? new Map<string, FinanceItem>();
+      const item =
+        skuMap.get(order.sku) ?? {
+          sku: order.sku,
+          costPrice: 0,
+          services: 0,
+          price: 0,
+          count: 0,
+          statuses: {},
+          other: {},
+          generalTransactions: {},
+        };
+      item.costPrice += unit.costPrice;
+      item.services += unit.totalServices;
+      item.price += unit.price;
+      item.count += 1;
+      item.statuses[unit.status] = (item.statuses[unit.status] ?? 0) + 1;
+      skuMap.set(order.sku, item);
+      monthMap.set(month, skuMap);
+      monthCounts.set(month, (monthCounts.get(month) ?? 0) + 1);
+    });
+
+    // other transactions (with sku but no postingNumber)
+    transactions
+      .filter((tx) => tx.sku && !tx.postingNumber)
+      .forEach((tx) => {
+        const month = dayjs(tx.date).format('MM-YYYY');
+        const sku = tx.sku as string;
+        const bySku = otherMap.get(month) ?? new Map<string, Record<string, number>>();
+        const nameMap = bySku.get(sku) ?? {};
+        nameMap[tx.name] = (nameMap[tx.name] ?? 0) + tx.price;
+        bySku.set(sku, nameMap);
+        otherMap.set(month, bySku);
+      });
+
+    // general transactions (without sku)
+    transactions
+      .filter((tx) => !tx.sku)
+      .forEach((tx) => {
+        const month = dayjs(tx.date).format('MM-YYYY');
+        const nameMap = generalMap.get(month) ?? {};
+        nameMap[tx.name] = (nameMap[tx.name] ?? 0) + tx.price;
+        generalMap.set(month, nameMap);
+      });
+
+    const months: FinanceMonth[] = [];
+    const overall = {
+      costPrice: 0,
+      services: 0,
+      price: 0,
+      count: 0,
+      statuses: {} as Record<string, number>,
+    };
+
+    monthMap.forEach((skuMap, month) => {
+      const items: FinanceItem[] = [];
+      const totals = {
+        costPrice: 0,
+        services: 0,
+        price: 0,
+        count: 0,
+        statuses: {} as Record<string, number>,
+      };
+
+      const otherBySku = otherMap.get(month);
+      const generalByName = generalMap.get(month) ?? {};
+      const totalCount = monthCounts.get(month) ?? 0;
+
+      skuMap.forEach((item, sku) => {
+        if (otherBySku && otherBySku.has(sku)) {
+          item.other = otherBySku.get(sku)!;
+        }
+        const generalTx: Record<string, number> = {};
+        if (totalCount > 0) {
+          Object.entries(generalByName).forEach(([name, sum]) => {
+            generalTx[name] = sum / totalCount;
+          });
+        }
+        item.generalTransactions = generalTx;
+        items.push(item);
+
+        totals.costPrice += item.costPrice;
+        totals.services += item.services;
+        totals.price += item.price;
+        totals.count += item.count;
+        Object.entries(item.statuses).forEach(([status, cnt]) => {
+          totals.statuses[status] = (totals.statuses[status] ?? 0) + cnt;
+        });
+      });
+
+      months.push({ month, items, totals });
+
+      overall.costPrice += totals.costPrice;
+      overall.services += totals.services;
+      overall.price += totals.price;
+      overall.count += totals.count;
+      Object.entries(totals.statuses).forEach(([status, cnt]) => {
+        overall.statuses[status] = (overall.statuses[status] ?? 0) + cnt;
+      });
+    });
+
+    return { months, totals: overall };
+  }
+}
+

--- a/src/modules/finance/finance.types.ts
+++ b/src/modules/finance/finance.types.ts
@@ -1,0 +1,27 @@
+export interface FinanceItem {
+  sku: string;
+  costPrice: number;
+  services: number;
+  price: number;
+  count: number;
+  statuses: Record<string, number>;
+  other: Record<string, number>;
+  generalTransactions: Record<string, number>;
+}
+
+export interface FinanceMonth {
+  month: string;
+  items: FinanceItem[];
+  totals: {
+    costPrice: number;
+    services: number;
+    price: number;
+    count: number;
+    statuses: Record<string, number>;
+  };
+}
+
+export interface FinanceAggregate {
+  months: FinanceMonth[];
+  totals: FinanceMonth['totals'];
+}

--- a/src/modules/transaction/dto/create-transaction.dto.ts
+++ b/src/modules/transaction/dto/create-transaction.dto.ts
@@ -2,6 +2,7 @@ export class CreateTransactionDto {
   operationId: string;
   name: string;
   date: Date;
-  postingNumber: string;
+  postingNumber?: string;
+  sku?: string | number;
   price: number;
 }

--- a/src/modules/transaction/entities/transaction.entity.ts
+++ b/src/modules/transaction/entities/transaction.entity.ts
@@ -5,7 +5,8 @@ export class TransactionEntity implements Transaction {
   operationId: string;
   name: string;
   date: Date;
-  postingNumber: string;
+  postingNumber: string | null;
+  sku: string | null;
   price: number;
 
   constructor(partial: Partial<Transaction>) {

--- a/src/modules/transaction/transaction.repository.ts
+++ b/src/modules/transaction/transaction.repository.ts
@@ -13,15 +13,24 @@ export class TransactionRepository {
   }
 
   create(data: CreateTransactionDto) {
+    const payload = {
+      ...data,
+      postingNumber: data.postingNumber ?? null,
+      sku:
+        data.sku === undefined || data.sku === null
+          ? null
+          : String(data.sku),
+    } as const;
+
     return this.prisma.transaction.upsert({
       where: {
         name_operationId: {
           name: data.name,
-          operationId: data.operationId
+          operationId: data.operationId,
         },
       },
-      create: data,
-      update: data,
+      create: payload,
+      update: payload,
     });
   }
 


### PR DESCRIPTION
## Summary
- add optional `sku` and `postingNumber` to transactions schema
- implement finance module to aggregate monthly SKU metrics and distribute transactions
- wire up finance module in application
- export finance types to resolve TS4053 errors
- normalize transaction `sku` values to strings and accept numeric SKUs

## Testing
- `npx prisma generate` *(fails: 403 Forbidden to registry)*
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: nest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72367395c832aa9cb771f14dd2044