### PR TITLE
feat: add finance module

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,8 @@ model Transaction {
   operationId   String
   name          String
   date          DateTime
-  postingNumber String
+  postingNumber String?
+  sku           String?
   price         Float
 
   @@unique([name, operationId])

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import {PrismaModule} from "./prisma/prisma.module";
 import {TransactionModule} from "./modules/transaction/transaction.module";
 import {OrderModule} from "./modules/order/order.module";
 import { UnitModule } from './modules/unit/unit.module';
+import { FinanceModule } from './modules/finance/finance.module';
 import { PerformanceApiModule } from "./api/performance/performance.module";
 import { SellerApiModule } from "./api/seller/seller.module";
 import ozonConfig from "@/config/ozon.config";
@@ -21,6 +22,7 @@ import ozonConfig from "@/config/ozon.config";
         TransactionModule,
         OrderModule,
         UnitModule,
+        FinanceModule,
         PerformanceApiModule,
         SellerApiModule,
     ],

--- a/src/modules/finance/finance.controller.ts
+++ b/src/modules/finance/finance.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { FinanceService } from './finance.service';
+import { FinanceAggregate } from './finance.types';
+
+@Controller('finance')
+export class FinanceController {
+  constructor(private readonly financeService: FinanceService) {}
+
+  @Get()
+  aggregate(): Promise<FinanceAggregate> {
+    return this.financeService.aggregate();
+  }
+}

--- a/src/modules/finance/finance.module.ts
+++ b/src/modules/finance/finance.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { FinanceService } from './finance.service';
+import { FinanceController } from './finance.controller';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { OrderRepository } from '@/modules/order/order.repository';
+import { TransactionRepository } from '@/modules/transaction/transaction.repository';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [FinanceController],
+  providers: [FinanceService, OrderRepository, TransactionRepository],
+})
+export class FinanceModule {}

--- a/src/modules/finance/finance.service.ts
+++ b/src/modules/finance/finance.service.ts
@@ -1,0 +1,299 @@
+import { Injectable } from '@nestjs/common';
+import { OrderRepository } from '@/modules/order/order.repository';
+import { TransactionRepository } from '@/modules/transaction/transaction.repository';
+import { Transaction } from '@prisma/client';
+import dayjs from 'dayjs';
+import Decimal from '@/shared/utils/decimal';
+import { UnitEntity } from '@/modules/unit/entities/unit.entity';
+import {
+  FinanceAggregate,
+  FinanceItem,
+  FinanceMonth,
+} from './finance.types';
+import { toDecimalUtils } from '@/shared/utils/to-decimal.utils';
+
+@Injectable()
+export class FinanceService {
+  constructor(
+    private readonly orderRepository: OrderRepository,
+    private readonly transactionRepository: TransactionRepository,
+  ) {}
+
+  private round2(value: Decimal.Value): number {
+    return new Decimal(value).toDecimalPlaces(2).toNumber();
+  }
+
+  private computeBuyout(statusCounts: Record<string, number>): number {
+    const delivered = toDecimalUtils(statusCounts['Доставлен']);
+    const cancelPvz = toDecimalUtils(statusCounts['Отмена ПВЗ']);
+    const returned = toDecimalUtils(statusCounts['Возврат']);
+    const instantCancel = toDecimalUtils(statusCounts['Моментальная отмена']);
+    const denom = delivered.plus(cancelPvz).plus(returned).plus(instantCancel);
+    if (denom.isZero()) {
+      return 0;
+    }
+    return this.round2(delivered.div(denom).times(100));
+  }
+
+  private groupTransactionsByPostingNumber(
+    transactions: Transaction[],
+  ): Map<string, Transaction[]> {
+    return transactions.reduce((map, tx) => {
+      if (!tx.postingNumber) {
+        return map;
+      }
+      const list = map.get(tx.postingNumber) ?? [];
+      list.push(tx);
+      map.set(tx.postingNumber, list);
+      return map;
+    }, new Map<string, Transaction[]>());
+  }
+
+  async aggregate(): Promise<FinanceAggregate> {
+    const [orders, transactions] = await Promise.all([
+      this.orderRepository.findAll(),
+      this.transactionRepository.findAll(),
+    ]);
+
+    const byPosting = this.groupTransactionsByPostingNumber(transactions);
+
+    const monthMap = new Map<string, Map<string, FinanceItem>>();
+    const monthCounts = new Map<string, number>();
+    const otherMap = new Map<string, Map<string, Record<string, number>>>();
+    const generalMap = new Map<string, Record<string, number>>();
+
+    // build items from orders
+    orders.forEach((order) => {
+      const numbers = [order.postingNumber, order.orderNumber];
+      const txs = numbers.flatMap((n) => byPosting.get(n) ?? []);
+      const uniqueTxs = [...new Map(txs.map((t) => [t.id, t])).values()];
+      const transactionTotal = uniqueTxs
+        .reduce((sum, t) => sum.plus(t.price), new Decimal(0))
+        .toNumber();
+      const unit = new UnitEntity({
+        ...order,
+        transactionTotal,
+        transactions: uniqueTxs,
+      });
+
+      const month = dayjs(order.createdAt).format('MM-YYYY');
+      const skuMap = monthMap.get(month) ?? new Map<string, FinanceItem>();
+      const item =
+        skuMap.get(order.sku) ?? {
+          sku: order.sku,
+          totalCost: 0,
+          totalServices: 0,
+          totalRevenue: 0,
+          salesCount: 0,
+          statusCounts: {},
+          otherTransactions: {},
+          sharedTransactions: {},
+          buyoutPercent: 0,
+          margin: 0,
+          marginPercent: 0,
+          profitabilityPercent: 0,
+        };
+      item.totalCost = toDecimalUtils(item.totalCost)
+        .plus(unit.costPrice)
+        .toNumber();
+      item.totalServices = toDecimalUtils(item.totalServices)
+        .plus(toDecimalUtils(unit.totalServices).abs())
+        .toNumber();
+      item.totalRevenue = toDecimalUtils(item.totalRevenue)
+        .plus(unit.price)
+        .toNumber();
+      item.salesCount += 1;
+      item.statusCounts[unit.status] = (item.statusCounts[unit.status] ?? 0) + 1;
+      skuMap.set(order.sku, item);
+      monthMap.set(month, skuMap);
+      monthCounts.set(month, (monthCounts.get(month) ?? 0) + 1);
+    });
+
+    // other transactions (with sku but no postingNumber)
+    transactions
+      .filter((tx) => tx.sku && !tx.postingNumber)
+      .forEach((tx) => {
+        const month = dayjs(tx.date).format('MM-YYYY');
+        const sku = tx.sku as string;
+        const bySku = otherMap.get(month) ?? new Map<string, Record<string, number>>();
+        const nameMap = bySku.get(sku) ?? {};
+        nameMap[tx.name] = toDecimalUtils(nameMap[tx.name])
+          .plus(toDecimalUtils(tx.price).abs())
+          .toNumber();
+        bySku.set(sku, nameMap);
+        otherMap.set(month, bySku);
+      });
+
+    // general transactions (without sku)
+    transactions
+      .filter((tx) => !tx.sku)
+      .forEach((tx) => {
+        const month = dayjs(tx.date).format('MM-YYYY');
+        const nameMap = generalMap.get(month) ?? {};
+        nameMap[tx.name] = toDecimalUtils(nameMap[tx.name])
+          .plus(toDecimalUtils(tx.price).abs())
+          .toNumber();
+        generalMap.set(month, nameMap);
+      });
+
+    const months: FinanceMonth[] = [];
+    const overall = {
+      totalCost: 0,
+      totalServices: 0,
+      totalRevenue: 0,
+      salesCount: 0,
+      statusCounts: {} as Record<string, number>,
+      buyoutPercent: 0,
+      margin: 0,
+      marginPercent: 0,
+      profitabilityPercent: 0,
+    };
+
+    monthMap.forEach((skuMap, month) => {
+      const items: FinanceItem[] = [];
+      const totals = {
+        totalCost: 0,
+        totalServices: 0,
+        totalRevenue: 0,
+        salesCount: 0,
+        statusCounts: {} as Record<string, number>,
+        buyoutPercent: 0,
+        margin: 0,
+        marginPercent: 0,
+        profitabilityPercent: 0,
+      };
+
+      const otherBySku = otherMap.get(month);
+      const generalByName = generalMap.get(month) ?? {};
+      const totalCount = monthCounts.get(month) ?? 0;
+
+      skuMap.forEach((item, sku) => {
+        if (otherBySku && otherBySku.has(sku)) {
+          item.otherTransactions = Object.fromEntries(
+            Object.entries(otherBySku.get(sku)!).map(([name, sum]) => [
+              name,
+              this.round2(toDecimalUtils(sum).abs()),
+            ]),
+          );
+        }
+        const sharedTx: Record<string, number> = {};
+        if (totalCount > 0) {
+          Object.entries(generalByName).forEach(([name, sum]) => {
+            sharedTx[name] = this.round2(
+              toDecimalUtils(sum).abs().div(totalCount),
+            );
+          });
+        }
+        item.sharedTransactions = sharedTx;
+        item.buyoutPercent = this.computeBuyout(item.statusCounts);
+        item.totalCost = this.round2(item.totalCost);
+        item.totalServices = this.round2(item.totalServices);
+        item.totalRevenue = this.round2(item.totalRevenue);
+        const otherSum = Object.values(item.otherTransactions).reduce(
+          (sum, val) => sum.plus(val),
+          new Decimal(0),
+        );
+        const sharedSum = Object.values(sharedTx).reduce(
+          (sum, val) => sum.plus(val),
+          new Decimal(0),
+        );
+        item.margin = this.round2(
+          toDecimalUtils(item.totalRevenue)
+            .minus(item.totalCost)
+            .minus(item.totalServices)
+            .minus(sharedSum)
+            .minus(otherSum),
+        );
+        const marginDecimal = toDecimalUtils(item.margin);
+        item.marginPercent =
+          item.totalRevenue > 0
+            ? this.round2(marginDecimal.div(item.totalRevenue).times(100))
+            : 0;
+        item.profitabilityPercent =
+          item.totalCost > 0
+            ? this.round2(marginDecimal.div(item.totalCost).times(100))
+            : 0;
+        items.push(item);
+
+        totals.totalCost = toDecimalUtils(totals.totalCost)
+          .plus(item.totalCost)
+          .toNumber();
+        totals.totalServices = toDecimalUtils(totals.totalServices)
+          .plus(item.totalServices)
+          .toNumber();
+        totals.totalRevenue = toDecimalUtils(totals.totalRevenue)
+          .plus(item.totalRevenue)
+          .toNumber();
+        totals.margin = toDecimalUtils(totals.margin)
+          .plus(item.margin)
+          .toNumber();
+        totals.salesCount += item.salesCount;
+        Object.entries(item.statusCounts).forEach(([status, cnt]) => {
+          totals.statusCounts[status] = (totals.statusCounts[status] ?? 0) + cnt;
+        });
+      });
+
+      totals.buyoutPercent = this.computeBuyout(totals.statusCounts);
+      totals.totalCost = this.round2(totals.totalCost);
+      totals.totalServices = this.round2(totals.totalServices);
+      totals.totalRevenue = this.round2(totals.totalRevenue);
+      totals.margin = this.round2(totals.margin);
+      const totalsMarginDecimal = toDecimalUtils(totals.margin);
+      totals.marginPercent =
+        totals.totalRevenue > 0
+          ? this.round2(
+              totalsMarginDecimal
+                .div(totals.totalRevenue)
+                .times(100),
+            )
+          : 0;
+      totals.profitabilityPercent =
+        totals.totalCost > 0
+          ? this.round2(
+              totalsMarginDecimal.div(totals.totalCost).times(100),
+            )
+          : 0;
+
+      months.push({ month, items, totals });
+
+      overall.totalCost = toDecimalUtils(overall.totalCost)
+        .plus(totals.totalCost)
+        .toNumber();
+      overall.totalServices = toDecimalUtils(overall.totalServices)
+        .plus(totals.totalServices)
+        .toNumber();
+      overall.totalRevenue = toDecimalUtils(overall.totalRevenue)
+        .plus(totals.totalRevenue)
+        .toNumber();
+      overall.margin = toDecimalUtils(overall.margin)
+        .plus(totals.margin)
+        .toNumber();
+      overall.salesCount += totals.salesCount;
+      Object.entries(totals.statusCounts).forEach(([status, cnt]) => {
+        overall.statusCounts[status] = (overall.statusCounts[status] ?? 0) + cnt;
+      });
+    });
+
+    overall.buyoutPercent = this.computeBuyout(overall.statusCounts);
+    overall.totalCost = this.round2(overall.totalCost);
+    overall.totalServices = this.round2(overall.totalServices);
+    overall.totalRevenue = this.round2(overall.totalRevenue);
+    overall.margin = this.round2(overall.margin);
+    const overallMarginDecimal = toDecimalUtils(overall.margin);
+    overall.marginPercent =
+      overall.totalRevenue > 0
+        ? this.round2(
+            overallMarginDecimal.div(overall.totalRevenue).times(100),
+          )
+        : 0;
+    overall.profitabilityPercent =
+      overall.totalCost > 0
+        ? this.round2(
+            overallMarginDecimal.div(overall.totalCost).times(100),
+          )
+        : 0;
+
+    return { months, totals: overall };
+  }
+}
+

--- a/src/modules/finance/finance.types.ts
+++ b/src/modules/finance/finance.types.ts
@@ -1,0 +1,35 @@
+export interface FinanceItem {
+  sku: string;
+  totalCost: number;
+  totalServices: number;
+  totalRevenue: number;
+  salesCount: number;
+  statusCounts: Record<string, number>;
+  otherTransactions: Record<string, number>;
+  sharedTransactions: Record<string, number>;
+  buyoutPercent: number;
+  margin: number;
+  marginPercent: number;
+  profitabilityPercent: number;
+}
+
+export interface FinanceMonth {
+  month: string;
+  items: FinanceItem[];
+  totals: {
+    totalCost: number;
+    totalServices: number;
+    totalRevenue: number;
+    salesCount: number;
+    statusCounts: Record<string, number>;
+    buyoutPercent: number;
+    margin: number;
+    marginPercent: number;
+    profitabilityPercent: number;
+  };
+}
+
+export interface FinanceAggregate {
+  months: FinanceMonth[];
+  totals: FinanceMonth['totals'];
+}

--- a/src/modules/transaction/dto/create-transaction.dto.ts
+++ b/src/modules/transaction/dto/create-transaction.dto.ts
@@ -2,6 +2,7 @@ export class CreateTransactionDto {
   operationId: string;
   name: string;
   date: Date;
-  postingNumber: string;
+  postingNumber?: string;
+  sku?: string | number;
   price: number;
 }

--- a/src/modules/transaction/entities/transaction.entity.ts
+++ b/src/modules/transaction/entities/transaction.entity.ts
@@ -5,7 +5,8 @@ export class TransactionEntity implements Transaction {
   operationId: string;
   name: string;
   date: Date;
-  postingNumber: string;
+  postingNumber: string | null;
+  sku: string | null;
   price: number;
 
   constructor(partial: Partial<Transaction>) {

--- a/src/modules/transaction/transaction.repository.ts
+++ b/src/modules/transaction/transaction.repository.ts
@@ -13,15 +13,24 @@ export class TransactionRepository {
   }
 
   create(data: CreateTransactionDto) {
+    const payload = {
+      ...data,
+      postingNumber: data.postingNumber ?? null,
+      sku:
+        data.sku === undefined || data.sku === null
+          ? null
+          : String(data.sku),
+    } as const;
+
     return this.prisma.transaction.upsert({
       where: {
         name_operationId: {
           name: data.name,
-          operationId: data.operationId
+          operationId: data.operationId,
         },
       },
-      create: data,
-      update: data,
+      create: payload,
+      update: payload,
     });
   }
 

--- a/src/modules/unit/entities/unit.entity.ts
+++ b/src/modules/unit/entities/unit.entity.ts
@@ -1,5 +1,5 @@
 import { Transaction } from '@prisma/client';
-import Decimal from 'decimal.js';
+import Decimal from '@/shared/utils/decimal';
 import { OrderEntity } from '@/modules/order/entities/order.entity';
 import { STATUS_RULES, DEFAULT_RULE } from '../utils/status-rules';
 import { EconomyContext } from '../ts/economy-context.interface';

--- a/src/modules/unit/ts/economy-context.interface.ts
+++ b/src/modules/unit/ts/economy-context.interface.ts
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js';
+import Decimal from '@/shared/utils/decimal';
 import { Service } from './service.interface';
 import { OzonStatus } from './ozon-status.enum';
 

--- a/src/modules/unit/ts/status-rule.type.ts
+++ b/src/modules/unit/ts/status-rule.type.ts
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js';
+import Decimal from '@/shared/utils/decimal';
 import { EconomyContext } from './economy-context.interface';
 import { CustomStatus } from './custom-status.enum';
 

--- a/src/shared/utils/decimal.ts
+++ b/src/shared/utils/decimal.ts
@@ -1,0 +1,6 @@
+import Decimal from 'decimal.js';
+
+// Configure Decimal.js for consistent precision and rounding across the app
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_UP });
+
+export default Decimal;

--- a/src/shared/utils/to-decimal.utils.ts
+++ b/src/shared/utils/to-decimal.utils.ts
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js';
+import Decimal from './decimal';
 
 export const toDecimalUtils = (value: number | string | undefined): Decimal =>
   new Decimal(value ?? 0);


### PR DESCRIPTION
## Summary
- add optional `sku` and `postingNumber` to transactions schema
- implement finance module to aggregate monthly SKU metrics and distribute transactions
- normalize service and transaction costs so margin calculation subtracts positive values
- wire up finance module in application
- export finance types to resolve TS4053 errors
- normalize transaction `sku` values to strings and accept numeric SKUs
- compute buyout percentages and clarify finance report field names with two-decimal rounding
- calculate margin per SKU and monthly totals as revenue minus costs, services, shared, and other transactions
- calculate margin and profitability percentages for each SKU and monthly/overall totals
- use decimal.js for all financial calculations to avoid floating-point errors
- centralize Decimal.js configuration in a shared utility

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@nestjs%2faxios)*
- `npx prisma generate` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: nest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72367395c832aa9cb771f14dd2044