### PR TITLE
feat: export unit data as csv

### DIFF
--- a/src/modules/unit/unit.controller.ts
+++ b/src/modules/unit/unit.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Header, Query } from '@nestjs/common';
 import { UnitService } from './unit.service';
 import { AggregateUnitDto } from './dto/aggregate-unit.dto';
 
@@ -9,5 +9,12 @@ export class UnitController {
   @Get()
   aggregate(@Query() dto: AggregateUnitDto) {
     return this.unitService.aggregate(dto);
+  }
+
+  @Get('csv')
+  @Header('Content-Type', 'text/csv')
+  @Header('Content-Disposition', 'attachment; filename="unit.csv"')
+  aggregateCsv(@Query() dto: AggregateUnitDto) {
+    return this.unitService.aggregateCsv(dto);
   }
 }

--- a/src/modules/unit/unit.service.ts
+++ b/src/modules/unit/unit.service.ts
@@ -93,4 +93,31 @@ export class UnitService {
 
     return { items: filteredItems, totals: [totals] };
   }
+
+  async aggregateCsv(dto: AggregateUnitDto): Promise<string> {
+    const { items } = await this.aggregate(dto);
+    const header = [
+      "orderNumber",
+      "postingNumber",
+      "sku",
+      "status",
+      "price",
+      "costPrice",
+      "margin",
+      "transactionTotal",
+    ];
+    const rows = items.map((item) =>
+      [
+        item.orderNumber,
+        item.postingNumber,
+        item.sku,
+        item.status,
+        item.price,
+        item.costPrice,
+        item.margin,
+        item.transactionTotal,
+      ].join(","),
+    );
+    return [header.join(","), ...rows].join("\n");
+  }
 }

--- a/test/unit.service.spec.ts
+++ b/test/unit.service.spec.ts
@@ -3,9 +3,13 @@ import { OrderRepository } from "@/modules/order/order.repository";
 import { TransactionRepository } from "@/modules/transaction/transaction.repository";
 import ordersFixture from "@/shared/data/orders.fixture";
 
-describe("UnitService.aggregate totals", () => {
-  it("sums price and costPrice only for delivered items", async () => {
-    const orders = ordersFixture.map((o) => ({
+describe("UnitService", () => {
+  let service: UnitService;
+  let orders: any[];
+  let transactions: any[];
+
+  beforeAll(() => {
+    orders = ordersFixture.map((o) => ({
       ...o,
       createdAt: new Date(o.createdAt),
       inProcessAt: new Date(o.inProcessAt),
@@ -14,18 +18,28 @@ describe("UnitService.aggregate totals", () => {
         date: new Date(t.date),
       })),
     }));
-    const transactions = orders.flatMap((o) => o.transactions);
+    transactions = orders.flatMap((o) => o.transactions);
     const orderRepository = {
       findAll: jest.fn().mockResolvedValue(orders),
     } as unknown as OrderRepository;
     const transactionRepository = {
       findAll: jest.fn().mockResolvedValue(transactions),
     } as unknown as TransactionRepository;
+    service = new UnitService(orderRepository, transactionRepository);
+  });
 
-    const service = new UnitService(orderRepository, transactionRepository);
+  it("sums price and costPrice only for delivered items", async () => {
     const result = await service.aggregate({});
-
     expect(result.totals[0].price).toBe(1000);
     expect(result.totals[0].costPrice).toBe(771);
+  });
+
+  it("returns csv representation of units", async () => {
+    const csv = await service.aggregateCsv({});
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe(
+      "orderNumber,postingNumber,sku,status,price,costPrice,margin,transactionTotal",
+    );
+    expect(lines.length).toBe(orders.length + 1);
   });
 });


### PR DESCRIPTION
## Summary
- allow retrieving unit aggregation as CSV via /unit/csv
- expose service method to generate CSV
- test CSV output

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c32cdce8832a8fc8caa9c1fd0c60