### PR TITLE
feat: export unit data as csv

### DIFF
--- a/src/modules/transaction/transaction.repository.ts
+++ b/src/modules/transaction/transaction.repository.ts
@@ -38,6 +38,12 @@ export class TransactionRepository {
     return this.prisma.transaction.findMany();
   }
 
+  findByPostingNumbers(postingNumbers: string[]) {
+    return this.prisma.transaction.findMany({
+      where: { postingNumber: { in: postingNumbers } },
+    });
+  }
+
   findLast(): Promise<Transaction | null> {
     return this.prisma.transaction.findFirst({ orderBy: { date: 'desc' } });
   }

--- a/test/unit.service.spec.ts
+++ b/test/unit.service.spec.ts
@@ -23,7 +23,13 @@ describe("UnitService", () => {
       findAll: jest.fn().mockResolvedValue(orders),
     } as unknown as OrderRepository;
     const transactionRepository = {
-      findAll: jest.fn().mockResolvedValue(transactions),
+      findByPostingNumbers: jest
+        .fn()
+        .mockImplementation((numbers: string[]) =>
+          Promise.resolve(
+            transactions.filter((t) => numbers.includes(t.postingNumber)),
+          ),
+        ),
     } as unknown as TransactionRepository;
     service = new UnitService(orderRepository, transactionRepository);
   });
@@ -38,8 +44,9 @@ describe("UnitService", () => {
     const csv = await service.aggregateCsv({});
     const lines = csv.trim().split("\n");
     expect(lines[0]).toBe(
-      "orderNumber,postingNumber,sku,status,price,costPrice,margin,transactionTotal",
+      "orderNumber,postingNumber,sku,status,price,costPrice,margin,transactionTotal,transactions",
     );
     expect(lines.length).toBe(orders.length + 1);
+    expect(csv).toContain("t2:-400");
   });
 });


### PR DESCRIPTION
## Summary
- allow retrieving unit aggregation as CSV via /unit/csv
- expose service method to generate CSV with transaction details
- test CSV output and transaction filtering

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c32cdce8832a8fc8caa9c1fd0c60