### PR TITLE
Refactor finance aggregation into modular helpers

### DIFF
--- a/src/modules/finance/finance-metrics.service.ts
+++ b/src/modules/finance/finance-metrics.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import Decimal from '@/shared/utils/decimal';
+import { toDecimalUtils } from '@/shared/utils/to-decimal.utils';
+
+@Injectable()
+export class FinanceMetricsService {
+  private round2(value: Decimal.Value): number {
+    return new Decimal(value).toDecimalPlaces(2).toNumber();
+  }
+
+  calculateBuyout(statusCounts: Record<string, number>): number {
+    const delivered = toDecimalUtils(statusCounts['\u0414\u043e\u0441\u0442\u0430\u0432\u043b\u0435\u043d']);
+    const cancelPvz = toDecimalUtils(statusCounts['\u041e\u0442\u043c\u0435\u043d\u0430 \u041f\u0412\u0417']);
+    const returned = toDecimalUtils(statusCounts['\u0412\u043e\u0437\u0432\u0440\u0430\u0442']);
+    const instantCancel = toDecimalUtils(statusCounts['\u041c\u043e\u043c\u0435\u043d\u0442\u0430\u043b\u044c\u043d\u0430\u044f \u043e\u0442\u043c\u0435\u043d\u0430']);
+    const denom = delivered.plus(cancelPvz).plus(returned).plus(instantCancel);
+    if (denom.isZero()) {
+      return 0;
+    }
+    return this.round2(delivered.div(denom).times(100));
+  }
+
+  calculateMargin(
+    totalRevenue: number,
+    totalCost: number,
+    totalServices: number,
+    sharedSum: Decimal.Value,
+    otherSum: Decimal.Value,
+  ): number {
+    return this.round2(
+      toDecimalUtils(totalRevenue)
+        .minus(totalCost)
+        .minus(totalServices)
+        .minus(sharedSum)
+        .minus(otherSum),
+    );
+  }
+
+  calculateMarginPercent(margin: number, totalRevenue: number): number {
+    const marginDecimal = toDecimalUtils(margin);
+    return totalRevenue > 0
+      ? this.round2(marginDecimal.div(totalRevenue).times(100))
+      : 0;
+  }
+
+  calculateProfitabilityPercent(margin: number, totalCost: number): number {
+    const marginDecimal = toDecimalUtils(margin);
+    return totalCost > 0
+      ? this.round2(marginDecimal.div(totalCost).times(100))
+      : 0;
+  }
+}
+

--- a/src/modules/finance/finance.module.ts
+++ b/src/modules/finance/finance.module.ts
@@ -5,10 +5,17 @@ import { PrismaModule } from '@/prisma/prisma.module';
 import { OrderRepository } from '@/modules/order/order.repository';
 import { TransactionRepository } from '@/modules/transaction/transaction.repository';
 import { UnitFactory } from '@/modules/unit/unit.factory';
+import { FinanceMetricsService } from './finance-metrics.service';
 
 @Module({
   imports: [PrismaModule],
   controllers: [FinanceController],
-  providers: [FinanceService, OrderRepository, TransactionRepository, UnitFactory],
+  providers: [
+    FinanceService,
+    OrderRepository,
+    TransactionRepository,
+    UnitFactory,
+    FinanceMetricsService,
+  ],
 })
 export class FinanceModule {}

--- a/test/finance-metrics.service.spec.ts
+++ b/test/finance-metrics.service.spec.ts
@@ -1,0 +1,26 @@
+import { FinanceMetricsService } from '@/modules/finance/finance-metrics.service';
+
+describe('FinanceMetricsService', () => {
+  let service: FinanceMetricsService;
+
+  beforeAll(() => {
+    service = new FinanceMetricsService();
+  });
+
+  it('calculates buyout percent', () => {
+    const percent = service.calculateBuyout({
+      '\u0414\u043e\u0441\u0442\u0430\u0432\u043b\u0435\u043d': 3,
+      '\u041e\u0442\u043c\u0435\u043d\u0430 \u041f\u0412\u0417': 1,
+      '\u0412\u043e\u0437\u0432\u0440\u0430\u0442': 1,
+      '\u041c\u043e\u043c\u0435\u043d\u0442\u0430\u043b\u044c\u043d\u0430\u044f \u043e\u0442\u043c\u0435\u043d\u0430': 0,
+    });
+    expect(percent).toBe(60);
+  });
+
+  it('calculates margin and percentages', () => {
+    const margin = service.calculateMargin(200, 100, 50, 10, 5);
+    expect(margin).toBe(35);
+    expect(service.calculateMarginPercent(margin, 200)).toBe(17.5);
+    expect(service.calculateProfitabilityPercent(margin, 100)).toBe(35);
+  });
+});

--- a/test/finance.service.spec.ts
+++ b/test/finance.service.spec.ts
@@ -1,0 +1,116 @@
+import { FinanceService } from '@/modules/finance/finance.service';
+import { OrderRepository } from '@/modules/order/order.repository';
+import { TransactionRepository } from '@/modules/transaction/transaction.repository';
+import { UnitFactory } from '@/modules/unit/unit.factory';
+import { FinanceMetricsService } from '@/modules/finance/finance-metrics.service';
+import ordersFixture from '@/shared/data/orders.fixture';
+
+// helper to convert fixture dates
+const prepareOrders = () =>
+  ordersFixture.map((o) => ({
+    ...o,
+    createdAt: new Date(o.createdAt),
+    inProcessAt: new Date(o.inProcessAt),
+    transactions: o.transactions.map((t) => ({
+      ...t,
+      date: new Date(t.date),
+    })),
+  }));
+
+describe('FinanceService helpers', () => {
+  let service: FinanceService;
+  let orderRepository: OrderRepository;
+  let transactionRepository: TransactionRepository;
+  let unitFactory: UnitFactory;
+
+  beforeEach(() => {
+    orderRepository = { findAll: jest.fn() } as any;
+    transactionRepository = { findAll: jest.fn() } as any;
+    unitFactory = new UnitFactory();
+    service = new FinanceService(
+      orderRepository,
+      transactionRepository,
+      unitFactory,
+      new FinanceMetricsService(),
+    );
+  });
+
+  it('loads orders and transactions', async () => {
+    (orderRepository.findAll as jest.Mock).mockResolvedValue([1]);
+    (transactionRepository.findAll as jest.Mock).mockResolvedValue([2]);
+    const result = await (service as any).loadOrdersAndTransactions();
+    expect(result).toEqual({ orders: [1], transactions: [2] });
+    expect(orderRepository.findAll).toHaveBeenCalled();
+    expect(transactionRepository.findAll).toHaveBeenCalled();
+  });
+
+  it('builds finance item using UnitFactory', () => {
+    const orders = prepareOrders();
+    const order = orders[0];
+    const txs = order.transactions;
+    const spy = jest.spyOn(unitFactory, 'createUnit');
+    const item = (service as any).buildFinanceItem(order, txs);
+    expect(spy).toHaveBeenCalledWith(order, txs);
+    expect(item.salesCount).toBe(1);
+    expect(item.statusCounts).toBeDefined();
+  });
+
+  it('builds transaction maps', () => {
+    const txs = [
+      {
+        id: '1',
+        name: 'Other',
+        price: 10,
+        date: new Date('2024-01-01'),
+        sku: '1',
+      },
+      {
+        id: '2',
+        name: 'General',
+        price: 20,
+        date: new Date('2024-01-01'),
+        sku: null,
+      },
+    ];
+    const { otherMap, generalMap } = (service as any).buildTransactionMaps(txs);
+    expect(otherMap.get('01-2024')?.get('1')?.Other).toBe(10);
+    expect(generalMap.get('01-2024')?.General).toBe(20);
+  });
+
+  it('applies transaction maps', () => {
+    const monthMap = new Map<string, Map<string, any>>();
+    const item = {
+      sku: '1',
+      totalCost: 0,
+      totalServices: 0,
+      totalRevenue: 0,
+      salesCount: 0,
+      statusCounts: {},
+      otherTransactions: {},
+      sharedTransactions: {},
+      buyoutPercent: 0,
+      margin: 0,
+      marginPercent: 0,
+      profitabilityPercent: 0,
+    };
+    monthMap.set('01-2024', new Map([['1', item]]));
+    const otherMap = new Map([
+      ['01-2024', new Map([['1', { Other: 10 }]])],
+    ]);
+    const generalMap = new Map([
+      ['01-2024', { General: 20 }],
+    ]);
+    const monthCounts = new Map([['01-2024', 1]]);
+
+    (service as any).applyTransactionMaps(
+      monthMap,
+      otherMap,
+      generalMap,
+      monthCounts,
+    );
+
+    const resultItem = monthMap.get('01-2024')!.get('1')!;
+    expect(resultItem.otherTransactions.Other).toBe(10);
+    expect(resultItem.sharedTransactions.General).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary
- extract finance helper methods and finance metrics service
- orchestrate finance aggregation with smaller steps
- add unit tests for new services and helpers

## Testing
- `npm test` *(fails: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c80f72a450832a911994f7a38ffcd6