### PR TITLE
Refactor advertising service logic

### DIFF
--- a/src/modules/advertising/advertising.service.ts
+++ b/src/modules/advertising/advertising.service.ts
@@ -1,30 +1,19 @@
-import {Injectable} from '@nestjs/common';
+import {Injectable, Logger} from '@nestjs/common';
 import {AdvertisingApiService} from "@/api/performance/advertising.service";
-import Decimal from '@/shared/utils/decimal';
 import {getDatesUntilToday} from '@/shared/utils/date.utils';
 import {parseNumber} from '@/shared/utils/parse-number.utils';
 import {toDecimal} from '@/shared/utils/to-decimal.utils';
 import {AdvertisingRepository} from "@/modules/advertising/advertising.repository";
 import {AdvertisingEntity} from "@/modules/advertising/entities/advertising.entity";
 import {CreateAdvertisingDto} from "@/modules/advertising/dto/create-advertising.dto";
+import {AdvertisingAccumulator} from "@/modules/advertising/utils/advertising-accumulator";
 
-type AdvertisingAccumulator = {
-    campaignId: string;
-    sku: string;
-    date: string;
-    type: 'CPC' | 'CPO';
-    clicks: number;
-    toCart: number;
-    avgBid: Decimal;
-    moneySpent: Decimal;
-    competitiveBid: Decimal;
-    minBidCpo: Decimal;
-    minBidCpoTop: Decimal;
-    weeklyBudget: Decimal;
-};
+const SPECIAL_CAMPAIGN_ID = '12950100';
 
 @Injectable()
 export class AdvertisingService {
+    private readonly logger = new Logger(AdvertisingService.name);
+
     constructor(
         private readonly advertisingApiService: AdvertisingApiService,
         private readonly advertisingRepository: AdvertisingRepository,
@@ -32,119 +21,189 @@ export class AdvertisingService {
     }
 
     async get(): Promise<AdvertisingEntity[]> {
+        this.logger.log('Starting advertising statistics synchronization');
         const dates = getDatesUntilToday('2025-09-21');
+        this.logger.debug(`Resolved ${dates.length} dates to process`);
         const result: AdvertisingEntity[] = [];
         const groupedCampaigns: Record<string, AdvertisingAccumulator> = {};
 
-        const addEntity = async (accumulator: AdvertisingAccumulator) => {
-            const dto: CreateAdvertisingDto = {
-                campaignId: accumulator.campaignId,
-                sku: accumulator.sku,
-                date: accumulator.date,
-                type: accumulator.type,
-                clicks: accumulator.clicks,
-                toCart: accumulator.toCart,
-                minBidCpo: accumulator.minBidCpo.toNumber(),
-                minBidCpoTop: accumulator.minBidCpoTop.toNumber(),
-                competitiveBid: accumulator.competitiveBid.toNumber(),
-                weeklyBudget: accumulator.weeklyBudget.toNumber(),
-                avgBid: accumulator.avgBid.toNumber(),
-                moneySpent: accumulator.moneySpent.toNumber(),
-            };
-            const entity = this.createEntity(dto);
-
-            result.push(entity);
-
-            await this.advertisingRepository.upsertMany([dto]);
-        };
-
         for (const date of dates) {
-            const items = await this.advertisingApiService.getDailyStatistics({
-                dateFrom: date,
-                dateTo: date,
-            });
+            this.logger.log(`Processing statistics for date ${date}`);
+            const statistics = await this.fetchStatisticsForDate(date);
 
-            const statistics = await this.advertisingApiService.getStatistics({
-                campaigns: items.rows.map((i) => i.id),
-                groupBy: "DATE",
-                dateFrom: date,
-                dateTo: date,
-            });
+            await this.processCampaignStatistics(date, statistics, result, groupedCampaigns);
+        }
 
-            for (const [campaignId, campaign] of Object.entries(statistics ?? {})) {
-                const rows = (campaign as any)?.report?.rows ?? [];
+        this.logger.log(`Persisting grouped campaigns: ${Object.keys(groupedCampaigns).length} accumulators`);
+        await this.persistGroupedCampaigns(groupedCampaigns, result);
 
-                for (const row of rows) {
-                    const skuValue = campaignId === '12950100' ? row?.advSku : row?.sku;
-                    const sku = skuValue === undefined || skuValue === null ? '' : String(skuValue);
-                    let competitiveBid = 0;
-                    let minBidCpo = 0;
-                    let minBidCpoTop = 0;
+        this.logger.log(`Finished synchronization with ${result.length} advertising entities`);
+        return result;
+    }
 
-                    const otherStats = await this.advertisingApiService.getStatisticsExpense({
-                        campaignIds: campaignId,
-                        dateFrom: date,
-                        dateTo: date,
-                    });
+    private async fetchStatisticsForDate(date: string): Promise<Record<string, unknown>> {
+        this.logger.debug(`Fetching daily statistics for ${date}`);
+        const dailyStatistics = await this.advertisingApiService.getDailyStatistics({
+            dateFrom: date,
+            dateTo: date,
+        });
+        const campaignIds = dailyStatistics?.rows?.map((row) => row.id) ?? [];
 
-                    if (campaignId !== '12950100') {
-                        const competitiveBidQuery = await this.advertisingApiService.getProductsBidsCompetitiveInCampaign(campaignId, {
-                            skus: sku,
-                        });
+        this.logger.debug(`Daily statistics for ${date} returned ${campaignIds.length} campaigns`);
 
-                        const minBidsCpoQuery = await this.advertisingApiService.getMinBidSku({
-                            sku: [sku],
-                            paymentType: 'CPC',
-                        });
+        if (!campaignIds.length) {
+            this.logger.warn(`No campaign ids returned for ${date}`);
+            return {};
+        }
 
-                        const minBidsCpoTopQuery = await this.advertisingApiService.getMinBidSku({
-                            sku: [sku],
-                            paymentType: 'CPC_TOP',
-                        });
+        this.logger.debug(`Fetching grouped statistics for campaigns ${campaignIds.join(', ')} on ${date}`);
+        return (await this.advertisingApiService.getStatistics({
+            campaigns: campaignIds,
+            groupBy: 'DATE',
+            dateFrom: date,
+            dateTo: date,
+        })) ?? {};
+    }
 
-                        minBidCpo = minBidsCpoQuery.minBids[0].bid ?? 0;
-                        minBidCpoTop = minBidsCpoTopQuery.minBids[0].bid ?? 0;
-                        competitiveBid = Math.floor(competitiveBidQuery.bids[0].bid / 1_000_000);
-                    }
+    private async processCampaignStatistics(
+        date: string,
+        statistics: Record<string, unknown>,
+        result: AdvertisingEntity[],
+        groupedCampaigns: Record<string, AdvertisingAccumulator>,
+    ): Promise<void> {
+        for (const [campaignId, campaign] of Object.entries(statistics)) {
+            this.logger.debug(`Processing campaign ${campaignId} for date ${date}`);
+            const rows = (campaign as any)?.report?.rows ?? [];
 
-                    const accumulator: AdvertisingAccumulator = {
-                        campaignId: campaignId === '12950100' ? `${row.date}-12950100` : campaignId,
-                        sku,
-                        date: String(row?.date ?? ''),
-                        type: campaignId === '12950100' ? 'CPO' : 'CPC',
-                        clicks: parseNumber(row?.clicks),
-                        toCart: parseNumber(row?.toCart),
-                        avgBid: toDecimal(row?.avgBid),
-                        competitiveBid: toDecimal(competitiveBid),
-                        minBidCpo: toDecimal(minBidCpo),
-                        minBidCpoTop: toDecimal(minBidCpoTop),
-                        moneySpent: toDecimal(row?.moneySpent),
-                        weeklyBudget: toDecimal(otherStats[0]?.weeklyBudget ?? 0),
-                    };
+            for (const row of rows) {
+                const accumulator = await this.buildAccumulator(date, campaignId, row);
 
-                    if (campaignId === '12950100') {
-                        const key = `${accumulator.date}_${accumulator.sku}`;
-                        const existing = groupedCampaigns[key];
-
-                        if (existing) {
-                            existing.clicks += accumulator.clicks;
-                            existing.toCart += accumulator.toCart;
-                            existing.moneySpent = existing.moneySpent.plus(accumulator.moneySpent);
-                        } else {
-                            groupedCampaigns[key] = accumulator;
-                        }
-                    } else {
-                        await addEntity(accumulator);
-                    }
+                if (campaignId === SPECIAL_CAMPAIGN_ID) {
+                    this.logger.debug(`Adding row to grouped campaign ${accumulator.aggregationKey}`);
+                    this.addToGroupedCampaigns(groupedCampaigns, accumulator);
+                    continue;
                 }
+
+                this.logger.debug(`Persisting accumulator for campaign ${campaignId} and SKU ${accumulator.sku}`);
+                const entity = await this.persistAccumulator(accumulator);
+                result.push(entity);
             }
         }
+    }
 
-        for (const accumulator of Object.values(groupedCampaigns)) {
-            await addEntity(accumulator);
+    private async buildAccumulator(date: string, campaignId: string, row: any): Promise<AdvertisingAccumulator> {
+        const sku = this.resolveSku(campaignId, row);
+        this.logger.debug(`Building accumulator for campaign ${campaignId}, date ${date}, sku ${sku}`);
+        const expenseStatistics = await this.advertisingApiService.getStatisticsExpense({
+            campaignIds: campaignId,
+            dateFrom: date,
+            dateTo: date,
+        });
+
+        let competitiveBid = 0;
+        let minBidCpo = 0;
+        let minBidCpoTop = 0;
+
+        if (campaignId !== SPECIAL_CAMPAIGN_ID) {
+            this.logger.debug(`Fetching bid information for campaign ${campaignId} and sku ${sku}`);
+            const competitiveBidQuery = await this.advertisingApiService.getProductsBidsCompetitiveInCampaign(campaignId, {
+                skus: sku,
+            });
+
+            const minBidsCpoQuery = await this.advertisingApiService.getMinBidSku({
+                sku: [sku],
+                paymentType: 'CPC',
+            });
+
+            const minBidsCpoTopQuery = await this.advertisingApiService.getMinBidSku({
+                sku: [sku],
+                paymentType: 'CPC_TOP',
+            });
+
+            const competitiveBidValue = competitiveBidQuery?.bids?.[0]?.bid ?? 0;
+            const minBidCpoValue = minBidsCpoQuery?.minBids?.[0]?.bid ?? 0;
+            const minBidCpoTopValue = minBidsCpoTopQuery?.minBids?.[0]?.bid ?? 0;
+
+            minBidCpo = minBidCpoValue;
+            minBidCpoTop = minBidCpoTopValue;
+            competitiveBid = Math.floor(competitiveBidValue / 1_000_000);
         }
 
-        return result;
+        const resolvedDate = this.resolveDate(row);
+        this.logger.debug(`Accumulator resolved date ${resolvedDate} for campaign ${campaignId}`);
+
+        return new AdvertisingAccumulator({
+            campaignId: campaignId === SPECIAL_CAMPAIGN_ID ? `${resolvedDate}-${SPECIAL_CAMPAIGN_ID}` : campaignId,
+            sku,
+            date: resolvedDate,
+            type: campaignId === SPECIAL_CAMPAIGN_ID ? 'CPO' : 'CPC',
+            clicks: parseNumber(row?.clicks),
+            toCart: parseNumber(row?.toCart),
+            avgBid: toDecimal(row?.avgBid),
+            competitiveBid: toDecimal(competitiveBid),
+            minBidCpo: toDecimal(minBidCpo),
+            minBidCpoTop: toDecimal(minBidCpoTop),
+            moneySpent: toDecimal(row?.moneySpent),
+            weeklyBudget: toDecimal(expenseStatistics?.[0]?.weeklyBudget ?? 0),
+        });
+    }
+
+    private resolveSku(campaignId: string, row: any): string {
+        const skuValue = campaignId === SPECIAL_CAMPAIGN_ID ? row?.advSku : row?.sku;
+
+        if (skuValue === undefined || skuValue === null) {
+            return '';
+        }
+
+        return String(skuValue);
+    }
+
+    private resolveDate(row: any): string {
+        const dateValue = row?.date;
+
+        if (dateValue === undefined || dateValue === null) {
+            return '';
+        }
+
+        return String(dateValue);
+    }
+
+    private addToGroupedCampaigns(
+        groupedCampaigns: Record<string, AdvertisingAccumulator>,
+        accumulator: AdvertisingAccumulator,
+    ): void {
+        const key = accumulator.aggregationKey;
+        const existing = groupedCampaigns[key];
+
+        if (existing) {
+            this.logger.debug(`Merging accumulator into existing grouped campaign ${key}`);
+            existing.mergeWith(accumulator);
+            return;
+        }
+
+        this.logger.debug(`Creating new grouped accumulator ${key}`);
+        groupedCampaigns[key] = accumulator;
+    }
+
+    private async persistGroupedCampaigns(
+        groupedCampaigns: Record<string, AdvertisingAccumulator>,
+        result: AdvertisingEntity[],
+    ): Promise<void> {
+        for (const accumulator of Object.values(groupedCampaigns)) {
+            this.logger.debug(`Persisting grouped accumulator ${accumulator.aggregationKey}`);
+            const entity = await this.persistAccumulator(accumulator);
+            result.push(entity);
+        }
+    }
+
+    private async persistAccumulator(accumulator: AdvertisingAccumulator): Promise<AdvertisingEntity> {
+        this.logger.debug(`Upserting advertising data for campaign ${accumulator.campaignId} and sku ${accumulator.sku}`);
+        const dto = accumulator.toDto();
+        const entity = this.createEntity(dto);
+
+        await this.advertisingRepository.upsertMany([dto]);
+
+        return entity;
     }
 
     private createEntity(dto: CreateAdvertisingDto): AdvertisingEntity {

--- a/src/modules/advertising/utils/advertising-accumulator.ts
+++ b/src/modules/advertising/utils/advertising-accumulator.ts
@@ -1,0 +1,81 @@
+import Decimal from '@/shared/utils/decimal';
+import {CreateAdvertisingDto} from '@/modules/advertising/dto/create-advertising.dto';
+import {AdvertisingEntity} from '@/modules/advertising/entities/advertising.entity';
+
+type AdvertisingAccumulatorType = 'CPC' | 'CPO';
+
+interface AdvertisingAccumulatorParams {
+    campaignId: string;
+    sku: string;
+    date: string;
+    type: AdvertisingAccumulatorType;
+    clicks: number;
+    toCart: number;
+    avgBid: Decimal;
+    moneySpent: Decimal;
+    competitiveBid: Decimal;
+    minBidCpo: Decimal;
+    minBidCpoTop: Decimal;
+    weeklyBudget: Decimal;
+}
+
+export class AdvertisingAccumulator {
+    readonly campaignId: string;
+    readonly sku: string;
+    readonly date: string;
+    readonly type: AdvertisingAccumulatorType;
+    clicks: number;
+    toCart: number;
+    readonly avgBid: Decimal;
+    moneySpent: Decimal;
+    readonly competitiveBid: Decimal;
+    readonly minBidCpo: Decimal;
+    readonly minBidCpoTop: Decimal;
+    readonly weeklyBudget: Decimal;
+
+    constructor(params: AdvertisingAccumulatorParams) {
+        this.campaignId = params.campaignId;
+        this.sku = params.sku;
+        this.date = params.date;
+        this.type = params.type;
+        this.clicks = params.clicks;
+        this.toCart = params.toCart;
+        this.avgBid = params.avgBid;
+        this.moneySpent = params.moneySpent;
+        this.competitiveBid = params.competitiveBid;
+        this.minBidCpo = params.minBidCpo;
+        this.minBidCpoTop = params.minBidCpoTop;
+        this.weeklyBudget = params.weeklyBudget;
+    }
+
+    get aggregationKey(): string {
+        return `${this.date}_${this.sku}`;
+    }
+
+    mergeWith(accumulator: AdvertisingAccumulator): void {
+        this.clicks += accumulator.clicks;
+        this.toCart += accumulator.toCart;
+        this.moneySpent = this.moneySpent.plus(accumulator.moneySpent);
+    }
+
+    toDto(): CreateAdvertisingDto {
+        return {
+            campaignId: this.campaignId,
+            sku: this.sku,
+            date: this.date,
+            type: this.type,
+            clicks: this.clicks,
+            toCart: this.toCart,
+            minBidCpo: this.minBidCpo.toNumber(),
+            minBidCpoTop: this.minBidCpoTop.toNumber(),
+            competitiveBid: this.competitiveBid.toNumber(),
+            weeklyBudget: this.weeklyBudget.toNumber(),
+            avgBid: this.avgBid.toNumber(),
+            moneySpent: this.moneySpent.toNumber(),
+        };
+    }
+
+    toEntity(): AdvertisingEntity {
+        return new AdvertisingEntity(this.toDto());
+    }
+}


### PR DESCRIPTION
## Summary
- extract helper methods in `AdvertisingService` to clarify data fetching, campaign processing, and persistence flows
- add reusable helpers for SKU/date resolution and DTO mapping while consolidating grouped campaign handling
- introduce an `AdvertisingAccumulator` utility to encapsulate aggregation, grouping, and persistence-ready DTO conversion
- add detailed logger instrumentation to trace each advertising synchronization step

## Testing
- npm test *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d02d46500c832a83e2acc79d7446ce