### PR TITLE
Remove transactionTotal duplication in UnitEntity

### DIFF
--- a/src/modules/unit/entities/unit.entity.ts
+++ b/src/modules/unit/entities/unit.entity.ts
@@ -9,7 +9,6 @@ import { OzonStatus } from '../ts/ozon-status.enum';
 import { toDecimalUtils } from '@/shared/utils/to-decimal.utils';
 
 export class UnitEntity extends OrderEntity {
-  transactionTotal: number;
   transactions: Transaction[];
   costPrice: number;
   totalServices: number;

--- a/src/modules/unit/unit.factory.ts
+++ b/src/modules/unit/unit.factory.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import Decimal from '@/shared/utils/decimal';
 import { Transaction } from '@prisma/client';
 import { UnitEntity } from './entities/unit.entity';
 import { OrderEntity } from '@/modules/order/entities/order.entity';
@@ -10,12 +9,8 @@ export class UnitFactory {
     const uniqueTxs = [
       ...new Map(transactions.map((t) => [t.id, t])).values(),
     ];
-    const transactionTotal = uniqueTxs
-      .reduce((sum, t) => sum.plus(t.price), new Decimal(0))
-      .toNumber();
     return new UnitEntity({
       ...order,
-      transactionTotal,
       transactions: uniqueTxs,
     });
   }

--- a/src/modules/unit/unit.service.ts
+++ b/src/modules/unit/unit.service.ts
@@ -60,7 +60,7 @@ export class UnitService {
             "status",
             "margin",
             "costPrice",
-            "transactionTotal",
+            "totalServices",
             "price"
         ];
         const rows = items.map((item) => {
@@ -71,7 +71,7 @@ export class UnitService {
                 item.status,
                 item.margin,
                 item.costPrice,
-                item.transactionTotal,
+                item.totalServices,
                 item.price,
             ].join(",");
         });

--- a/test/unit.service.spec.ts
+++ b/test/unit.service.spec.ts
@@ -51,7 +51,7 @@ describe("UnitService", () => {
     const csv = await service.aggregateCsv({});
     const lines = csv.trim().split("\n");
     expect(lines[0]).toBe(
-      "orderNumber,postingNumber,sku,status,price,costPrice,margin,transactionTotal,transactions",
+      "orderNumber,postingNumber,sku,status,price,costPrice,margin,totalServices,transactions",
     );
     expect(lines.length).toBe(orders.length + 1);
     expect(csv).toContain("t2:-400");


### PR DESCRIPTION
## Summary
- remove the redundant `transactionTotal` property from `UnitEntity` and its factory
- switch CSV export to use `totalServices` instead of the removed field
- update unit tests to reflect the CSV header change

## Testing
- npm test *(fails: jest not found because dependencies cannot be installed – @nestjs/axios@^10.0.0 has no matching version)*

------
https://chatgpt.com/codex/tasks/task_e_68d5625e63e4832ab19cc959f9b3bdee