### PR TITLE
Add monthly advertising expense distribution to unit metrics

### DIFF
--- a/src/modules/advertising/advertising.repository.ts
+++ b/src/modules/advertising/advertising.repository.ts
@@ -88,4 +88,18 @@ export class AdvertisingRepository {
 
     return this.prisma.$transaction(operations);
   }
+
+  async sumMoneySpentByDateRange(dateFrom: string, dateTo: string): Promise<number> {
+    const { _sum } = await this.prisma.advertising.aggregate({
+      _sum: { moneySpent: true },
+      where: {
+        date: {
+          gte: dateFrom,
+          lte: dateTo,
+        },
+      },
+    });
+
+    return _sum.moneySpent ?? 0;
+  }
 }

--- a/src/modules/order/order.repository.ts
+++ b/src/modules/order/order.repository.ts
@@ -15,6 +15,17 @@ export class OrderRepository {
     return this.prisma.order.findMany({ where });
   }
 
+  countByCreatedAtRange(from: Date, to: Date): Promise<number> {
+    return this.prisma.order.count({
+      where: {
+        createdAt: {
+          gte: from,
+          lte: to,
+        },
+      },
+    });
+  }
+
   upsert(data: CreateOrderDto): Promise<Order> {
     return this.prisma.order.upsert({
       where: { postingNumber: data.postingNumber },

--- a/src/modules/unit/entities/unit.entity.ts
+++ b/src/modules/unit/entities/unit.entity.ts
@@ -13,12 +13,14 @@ export class UnitEntity extends OrderEntity {
   costPrice: number;
   totalServices: number;
   margin: number;
+  advertisingExpense: number;
   private statusOzon: OzonStatus | string;
 
   constructor(partial: Partial<UnitEntity>) {
     super(partial);
     Object.assign(this, partial);
     this.statusOzon = (partial.status as OzonStatus) ?? "";
+    this.advertisingExpense = partial.advertisingExpense ?? 0;
     const services = this.buildServices();
     const economy = this.calculateEconomy(services);
     this.status = economy.status;
@@ -28,10 +30,16 @@ export class UnitEntity extends OrderEntity {
   }
 
   private buildServices(): Service[] {
-    return (this.transactions ?? []).map((tx) => ({
+    const services = (this.transactions ?? []).map((tx) => ({
       name: tx.name,
       price: tx.price,
     }));
+
+    if (this.advertisingExpense) {
+      services.push({ name: 'Advertising', price: -this.advertisingExpense });
+    }
+
+    return services;
   }
 
   private getPriceDecimal(): Decimal {

--- a/src/modules/unit/unit.factory.ts
+++ b/src/modules/unit/unit.factory.ts
@@ -5,13 +5,18 @@ import { OrderEntity } from '@/modules/order/entities/order.entity';
 
 @Injectable()
 export class UnitFactory {
-  createUnit(order: OrderEntity, transactions: Transaction[]): UnitEntity {
-    const uniqueTxs = [
-      ...new Map(transactions.map((t) => [t.id, t])).values(),
-    ];
-    return new UnitEntity({
-      ...order,
-      transactions: uniqueTxs,
-    });
-  }
+    createUnit(
+        order: OrderEntity,
+        transactions: Transaction[],
+        advertisingExpense = 0,
+    ): UnitEntity {
+        const uniqueTxs = [
+            ...new Map(transactions.map((t) => [t.id, t])).values(),
+        ];
+        return new UnitEntity({
+            ...order,
+            transactions: uniqueTxs,
+            advertisingExpense,
+        });
+    }
 }

--- a/src/modules/unit/unit.module.ts
+++ b/src/modules/unit/unit.module.ts
@@ -5,11 +5,18 @@ import { PrismaModule } from '@/prisma/prisma.module';
 import { OrderRepository } from '@/modules/order/order.repository';
 import { TransactionRepository } from '@/modules/transaction/transaction.repository';
 import { UnitFactory } from './unit.factory';
+import { AdvertisingRepository } from '@/modules/advertising/advertising.repository';
 
 @Module({
   imports: [PrismaModule],
   controllers: [UnitController],
-  providers: [UnitService, OrderRepository, TransactionRepository, UnitFactory],
+  providers: [
+    UnitService,
+    OrderRepository,
+    TransactionRepository,
+    UnitFactory,
+    AdvertisingRepository,
+  ],
   exports: [UnitFactory],
 })
 export class UnitModule {}

--- a/src/modules/unit/unit.service.ts
+++ b/src/modules/unit/unit.service.ts
@@ -1,12 +1,15 @@
-import {Injectable} from "@nestjs/common";
-import {OrderRepository} from "@/modules/order/order.repository";
-import {TransactionRepository} from "@/modules/transaction/transaction.repository";
-import {groupTransactionsByPostingNumber} from "@/shared/utils/transaction.utils";
-import {AggregateUnitDto} from "./dto/aggregate-unit.dto";
-import {UnitEntity} from "./entities/unit.entity";
-import {buildOrderWhere} from "./utils/order-filter.utils";
-import {UnitFactory} from "./unit.factory";
-import dayjs from "dayjs";
+import { Injectable } from '@nestjs/common';
+import { OrderRepository } from '@/modules/order/order.repository';
+import { TransactionRepository } from '@/modules/transaction/transaction.repository';
+import { groupTransactionsByPostingNumber } from '@/shared/utils/transaction.utils';
+import { AggregateUnitDto } from './dto/aggregate-unit.dto';
+import { UnitEntity } from './entities/unit.entity';
+import { buildOrderWhere } from './utils/order-filter.utils';
+import { UnitFactory } from './unit.factory';
+import dayjs from 'dayjs';
+import { AdvertisingRepository } from '@/modules/advertising/advertising.repository';
+import { Order } from '@prisma/client';
+import { toDecimalUtils } from '@/shared/utils/to-decimal.utils';
 
 @Injectable()
 export class UnitService {
@@ -14,6 +17,7 @@ export class UnitService {
         private readonly orderRepository: OrderRepository,
         private readonly transactionRepository: TransactionRepository,
         private readonly unitFactory: UnitFactory,
+        private readonly advertisingRepository: AdvertisingRepository,
     ) {
     }
 
@@ -21,6 +25,9 @@ export class UnitService {
         const where = buildOrderWhere(dto);
 
         const orders = await this.orderRepository.findAll(where);
+        if (!orders.length) {
+            return [];
+        }
         const postingNumbers = Array.from(
             new Set(
                 orders
@@ -33,13 +40,16 @@ export class UnitService {
         );
 
         const byNumber = groupTransactionsByPostingNumber(transactions);
+        const advertisingByMonth = await this.getAdvertisingExpensesPerUnit(orders);
 
         const items = orders.map((order) => {
             const numbers = [order.postingNumber, order.orderNumber];
             const orderTransactions = numbers.flatMap(
                 (num) => byNumber.get(num) ?? [],
             );
-            return this.unitFactory.createUnit(order, orderTransactions);
+            const monthKey = dayjs(order.createdAt).format('YYYY-MM');
+            const advertisingExpense = advertisingByMonth.get(monthKey) ?? 0;
+            return this.unitFactory.createUnit(order, orderTransactions, advertisingExpense);
         });
 
         const statuses = dto.status
@@ -61,7 +71,8 @@ export class UnitService {
             "margin",
             "costPrice",
             "totalServices",
-            "price"
+            "price",
+            "advertisingExpense",
         ];
         const rows = items.map((item) => {
             return [
@@ -73,8 +84,65 @@ export class UnitService {
                 item.costPrice,
                 item.totalServices,
                 item.price,
+                item.advertisingExpense,
             ].join(",");
         });
         return [header.join(","), ...rows].join("\n");
+    }
+
+    private async getAdvertisingExpensesPerUnit(orders: Order[]): Promise<Map<string, number>> {
+        const months = new Map<string, {
+            monthStart: Date;
+            monthEnd: Date;
+            monthStartString: string;
+            monthEndString: string;
+        }>();
+
+        orders.forEach((order) => {
+            const createdAt = dayjs(order.createdAt);
+            const monthKey = createdAt.format('YYYY-MM');
+            if (months.has(monthKey)) {
+                return;
+            }
+
+            const startOfMonth = createdAt.startOf('month');
+            const endOfMonth = createdAt.endOf('month');
+
+            months.set(monthKey, {
+                monthStart: startOfMonth.toDate(),
+                monthEnd: endOfMonth.toDate(),
+                monthStartString: startOfMonth.format('YYYY-MM-DD'),
+                monthEndString: endOfMonth.format('YYYY-MM-DD'),
+            });
+        });
+
+        if (!months.size) {
+            return new Map();
+        }
+
+        const advertisingPairs = await Promise.all(
+            Array.from(months.entries()).map(async ([monthKey, range]) => {
+                const [ordersCount, advertisingSum] = await Promise.all([
+                    this.orderRepository.countByCreatedAtRange(range.monthStart, range.monthEnd),
+                    this.advertisingRepository.sumMoneySpentByDateRange(
+                        range.monthStartString,
+                        range.monthEndString,
+                    ),
+                ]);
+
+                if (!ordersCount) {
+                    return [monthKey, 0] as const;
+                }
+
+                const perUnit = toDecimalUtils(advertisingSum)
+                    .dividedBy(ordersCount)
+                    .toDecimalPlaces(2)
+                    .toNumber();
+
+                return [monthKey, perUnit] as const;
+            }),
+        );
+
+        return new Map(advertisingPairs);
     }
 }

--- a/test/unit.entity.spec.ts
+++ b/test/unit.entity.spec.ts
@@ -67,4 +67,26 @@ describe('UnitEntity status calculation', () => {
         const unit = new UnitEntity(getOrder('delivering'));
         expect(unit.status).toBe(CustomStatus.Delivering);
     });
+
+    it('should include advertising expense in total services and margin', () => {
+        const unit = new UnitEntity({
+            id: 'advertising-test',
+            product: 'test',
+            orderId: 'order',
+            orderNumber: 'order-number',
+            postingNumber: 'posting-number',
+            status: 'delivered',
+            createdAt: new Date('2024-01-01T00:00:00.000Z'),
+            inProcessAt: new Date('2024-01-02T00:00:00.000Z'),
+            sku: 'sku',
+            oldPrice: 1000,
+            price: 1000,
+            currencyCode: 'RUB',
+            transactions: [],
+            advertisingExpense: 50,
+        } as any);
+
+        expect(unit.totalServices).toBeCloseTo(-50);
+        expect(unit.margin).toBeCloseTo(-50);
+    });
 });

--- a/test/unit.service.spec.ts
+++ b/test/unit.service.spec.ts
@@ -3,14 +3,26 @@ import { OrderRepository } from "@/modules/order/order.repository";
 import { TransactionRepository } from "@/modules/transaction/transaction.repository";
 import { UnitFactory } from "@/modules/unit/unit.factory";
 import ordersFixture from "@/shared/data/orders.fixture";
+import { AdvertisingRepository } from "@/modules/advertising/advertising.repository";
+import dayjs from "dayjs";
 
 describe("UnitService", () => {
   let service: UnitService;
   let orders: any[];
   let transactions: any[];
   let unitFactory: UnitFactory;
+  let orderRepositoryMock: {
+    findAll: jest.Mock;
+    countByCreatedAtRange: jest.Mock;
+  };
+  let transactionRepositoryMock: {
+    findByPostingNumbers: jest.Mock;
+  };
+  let advertisingRepositoryMock: {
+    sumMoneySpentByDateRange: jest.Mock;
+  };
 
-  beforeAll(() => {
+  beforeEach(() => {
     orders = ordersFixture.map((o) => ({
       ...o,
       createdAt: new Date(o.createdAt),
@@ -21,10 +33,13 @@ describe("UnitService", () => {
       })),
     }));
     transactions = orders.flatMap((o) => o.transactions);
-    const orderRepository = {
+
+    orderRepositoryMock = {
       findAll: jest.fn().mockResolvedValue(orders),
-    } as unknown as OrderRepository;
-    const transactionRepository = {
+      countByCreatedAtRange: jest.fn().mockResolvedValue(orders.length),
+    };
+
+    transactionRepositoryMock = {
       findByPostingNumbers: jest
         .fn()
         .mockImplementation((numbers: string[]) =>
@@ -32,34 +47,54 @@ describe("UnitService", () => {
             transactions.filter((t) => numbers.includes(t.postingNumber)),
           ),
         ),
-    } as unknown as TransactionRepository;
+    };
+
+    advertisingRepositoryMock = {
+      sumMoneySpentByDateRange: jest.fn().mockResolvedValue(400),
+    };
+
     unitFactory = new UnitFactory();
     service = new UnitService(
-      orderRepository,
-      transactionRepository,
+      orderRepositoryMock as unknown as OrderRepository,
+      transactionRepositoryMock as unknown as TransactionRepository,
       unitFactory,
+      advertisingRepositoryMock as unknown as AdvertisingRepository,
     );
   });
 
-  it("sums price and costPrice only for delivered items", async () => {
+  it("distributes monthly advertising expenses across units", async () => {
     const result = await service.aggregate({});
-    expect(result.totals[0].price).toBe(1000);
-    expect(result.totals[0].costPrice).toBe(771);
+
+    expect(result).toHaveLength(orders.length);
+    expect(result[0].advertisingExpense).toBe(50);
+    expect(advertisingRepositoryMock.sumMoneySpentByDateRange).toHaveBeenCalledWith(
+      "2024-01-01",
+      "2024-01-31",
+    );
+    const [from, to] = orderRepositoryMock.countByCreatedAtRange.mock.calls[0];
+    expect(dayjs(from).format("YYYY-MM-DD")).toBe("2024-01-01");
+    expect(dayjs(to).format("YYYY-MM-DD")).toBe("2024-01-31");
   });
 
-  it("returns csv representation of units", async () => {
+  it("includes advertising expense in CSV export", async () => {
     const csv = await service.aggregateCsv({});
     const lines = csv.trim().split("\n");
+
     expect(lines[0]).toBe(
-      "orderNumber,postingNumber,sku,status,price,costPrice,margin,totalServices,transactions",
+      "product,postingNumber,createdAt,status,margin,costPrice,totalServices,price,advertisingExpense",
     );
     expect(lines.length).toBe(orders.length + 1);
-    expect(csv).toContain("t2:-400");
+    const firstRow = lines[1].split(",");
+    expect(firstRow[firstRow.length - 1]).toBe("50");
   });
 
-  it("uses UnitFactory to create units", async () => {
+  it("passes advertising expense to UnitFactory", async () => {
     const spy = jest.spyOn(unitFactory, "createUnit");
     await service.aggregate({});
+
     expect(spy).toHaveBeenCalledTimes(orders.length);
+    spy.mock.calls.forEach(([, , advertisingExpense]) => {
+      expect(advertisingExpense).toBe(50);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- calculate monthly advertising spend per order and attach it to unit aggregation and CSV export
- expose repository helpers to sum advertising costs and count orders for the month
- cover the new advertising flow with updated unit service and entity tests

## Testing
- npm test *(fails: jest not found in runtime environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d671bf353c832a8547c3b14db8790f