### PR TITLE
Adjust advertising synchronization start date

### DIFF
--- a/src/modules/advertising/advertising.repository.ts
+++ b/src/modules/advertising/advertising.repository.ts
@@ -88,4 +88,17 @@ export class AdvertisingRepository {
 
     return this.prisma.$transaction(operations);
   }
+
+  async findLatestDate(): Promise<string | null> {
+    const latest = await this.prisma.advertising.findFirst({
+      select: {
+        date: true,
+      },
+      orderBy: {
+        date: 'desc',
+      },
+    });
+
+    return latest?.date ?? null;
+  }
 }

--- a/src/modules/advertising/advertising.service.ts
+++ b/src/modules/advertising/advertising.service.ts
@@ -82,7 +82,10 @@ export class AdvertisingService {
 
     async get(): Promise<AdvertisingEntity[]> {
         this.logger.log('Starting advertising statistics synchronization');
-        const dates = getDatesUntilToday('2025-09-21');
+        const latestDate = await this.advertisingRepository.findLatestDate();
+        const startDate = latestDate ?? '2025-09-01';
+        this.logger.debug(`Resolved start date for synchronization: ${startDate}`);
+        const dates = getDatesUntilToday(startDate);
         this.logger.debug(`Resolved ${dates.length} dates to process`);
         const result: AdvertisingEntity[] = [];
         const groupedCampaigns: Record<string, AdvertisingAccumulator> = {};


### PR DESCRIPTION
## Summary
- derive the advertising synchronization start date from the latest stored record when available
- add a repository helper for retrieving the most recent advertising date

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d694ce7028832a9433fc0b2f7e03a9