### PR TITLE
refactor: extract CSV generation services

### DIFF
--- a/src/modules/advertising/advertising.controller.ts
+++ b/src/modules/advertising/advertising.controller.ts
@@ -1,10 +1,14 @@
 import { Controller, Get, Header, Query } from '@nestjs/common';
 import {AdvertisingService} from "@/modules/advertising/advertising.service";
 import {FilterAdvertisingDto} from "@/modules/advertising/dto/filter-advertising.dto";
+import {AdvertisingCsvService} from "@/modules/advertising/services/advertising-csv.service";
 
 @Controller('advertising')
 export class AdvertisingController {
-  constructor(private readonly advertisingService: AdvertisingService) {}
+  constructor(
+    private readonly advertisingService: AdvertisingService,
+    private readonly advertisingCsvService: AdvertisingCsvService,
+  ) {}
 
   @Get()
   get() {
@@ -15,6 +19,6 @@ export class AdvertisingController {
   @Header('Content-Type', 'text/csv')
   @Header('Content-Disposition', 'attachment; filename="advertising.csv"')
   findManyCsv(@Query() dto: FilterAdvertisingDto) {
-    return this.advertisingService.findManyCsv(dto);
+    return this.advertisingCsvService.findManyCsv(dto);
   }
 }

--- a/src/modules/advertising/advertising.module.ts
+++ b/src/modules/advertising/advertising.module.ts
@@ -6,11 +6,12 @@ import {PerformanceApiModule} from "@/api/performance/performance.module";
 import {AdvertisingService} from "@/modules/advertising/advertising.service";
 import {AdvertisingRepository} from "@/modules/advertising/advertising.repository";
 import {CpoParserService} from "@/modules/advertising/services/cpo-parser.service";
+import {AdvertisingCsvService} from "@/modules/advertising/services/advertising-csv.service";
 
 @Module({
     imports: [PrismaModule, PerformanceApiModule],
     controllers: [AdvertisingController],
-    providers: [AdvertisingApiService, AdvertisingService, AdvertisingRepository, CpoParserService],
+    providers: [AdvertisingApiService, AdvertisingService, AdvertisingRepository, CpoParserService, AdvertisingCsvService],
 })
 export class AdvertisingModule {
 }

--- a/src/modules/advertising/advertising.service.ts
+++ b/src/modules/advertising/advertising.service.ts
@@ -26,59 +26,6 @@ export class AdvertisingService {
         return items.map((item) => new AdvertisingEntity(item));
     }
 
-    async findManyCsv(filters: FilterAdvertisingDto): Promise<string> {
-        const items = await this.findMany(filters);
-        const header = [
-            'id',
-            'campaignId',
-            'sku',
-            'date',
-            'type',
-            'clicks',
-            'toCart',
-            'avgBid',
-            'moneySpent',
-            'minBidCpo',
-            'minBidCpoTop',
-            'competitiveBid',
-            'weeklyBudget',
-            'createdAt',
-        ];
-
-        const rows = items.map((item) =>
-            [
-                item.id,
-                item.campaignId,
-                item.sku,
-                item.date,
-                item.type,
-                item.clicks,
-                item.toCart,
-                item.avgBid,
-                item.moneySpent,
-                item.minBidCpo,
-                item.minBidCpoTop,
-                item.competitiveBid,
-                item.weeklyBudget,
-                item.createdAt,
-            ]
-                .map((value) => {
-                    if (value instanceof Date) {
-                        return value.toISOString();
-                    }
-
-                    if (value === undefined || value === null) {
-                        return '';
-                    }
-
-                    return String(value);
-                })
-                .join(','),
-        );
-
-        return [header.join(','), ...rows].join('\n');
-    }
-
     async getStatisticsExpense(date) {
         const ads = await this.advertisingApiService.getStatisticsExpense({
             from: date + 'T21:00:00Z',

--- a/src/modules/advertising/services/advertising-csv.service.ts
+++ b/src/modules/advertising/services/advertising-csv.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { AdvertisingService } from '@/modules/advertising/advertising.service';
+import { FilterAdvertisingDto } from '@/modules/advertising/dto/filter-advertising.dto';
+
+@Injectable()
+export class AdvertisingCsvService {
+    constructor(private readonly advertisingService: AdvertisingService) {}
+
+    async findManyCsv(filters: FilterAdvertisingDto): Promise<string> {
+        const items = await this.advertisingService.findMany(filters);
+        const header = [
+            'id',
+            'campaignId',
+            'sku',
+            'date',
+            'type',
+            'clicks',
+            'toCart',
+            'avgBid',
+            'moneySpent',
+            'minBidCpo',
+            'minBidCpoTop',
+            'competitiveBid',
+            'weeklyBudget',
+            'createdAt',
+        ];
+
+        const rows = items.map((item) =>
+            [
+                item.id,
+                item.campaignId,
+                item.sku,
+                item.date,
+                item.type,
+                item.clicks,
+                item.toCart,
+                item.avgBid,
+                item.moneySpent,
+                item.minBidCpo,
+                item.minBidCpoTop,
+                item.competitiveBid,
+                item.weeklyBudget,
+                item.createdAt,
+            ]
+                .map((value) => {
+                    if (value instanceof Date) {
+                        return value.toISOString();
+                    }
+
+                    if (value === undefined || value === null) {
+                        return '';
+                    }
+
+                    return String(value);
+                })
+                .join(','),
+        );
+
+        return [header.join(','), ...rows].join('\n');
+    }
+}

--- a/src/modules/unit/services/unit-csv.service.ts
+++ b/src/modules/unit/services/unit-csv.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { UnitService } from '@/modules/unit/unit.service';
+import { AggregateUnitDto } from '@/modules/unit/dto/aggregate-unit.dto';
+import dayjs from 'dayjs';
+
+@Injectable()
+export class UnitCsvService {
+    constructor(private readonly unitService: UnitService) {}
+
+    async aggregateCsv(dto: AggregateUnitDto): Promise<string> {
+        const items = await this.unitService.aggregate(dto);
+        const header = [
+            'product',
+            'postingNumber',
+            'createdAt',
+            'status',
+            'margin',
+            'costPrice',
+            'totalServices',
+            'price',
+        ];
+        const rows = items.map((item) => {
+            return [
+                item.product,
+                item.postingNumber,
+                dayjs(item.createdAt).format('YYYY-MM'),
+                item.status,
+                item.margin,
+                item.costPrice,
+                item.totalServices,
+                item.price,
+            ].join(',');
+        });
+        return [header.join(','), ...rows].join('\n');
+    }
+}

--- a/src/modules/unit/unit.controller.ts
+++ b/src/modules/unit/unit.controller.ts
@@ -1,10 +1,14 @@
 import { Controller, Get, Header, Query } from '@nestjs/common';
 import { UnitService } from './unit.service';
 import { AggregateUnitDto } from './dto/aggregate-unit.dto';
+import { UnitCsvService } from '@/modules/unit/services/unit-csv.service';
 
 @Controller('unit')
 export class UnitController {
-  constructor(private readonly unitService: UnitService) {}
+  constructor(
+    private readonly unitService: UnitService,
+    private readonly unitCsvService: UnitCsvService,
+  ) {}
 
   @Get()
   aggregate(@Query() dto: AggregateUnitDto) {
@@ -15,6 +19,6 @@ export class UnitController {
   @Header('Content-Type', 'text/csv')
   @Header('Content-Disposition', 'attachment; filename="unit.csv"')
   aggregateCsv(@Query() dto: AggregateUnitDto) {
-    return this.unitService.aggregateCsv(dto);
+    return this.unitCsvService.aggregateCsv(dto);
   }
 }

--- a/src/modules/unit/unit.module.ts
+++ b/src/modules/unit/unit.module.ts
@@ -5,11 +5,12 @@ import { PrismaModule } from '@/prisma/prisma.module';
 import { OrderRepository } from '@/modules/order/order.repository';
 import { TransactionRepository } from '@/modules/transaction/transaction.repository';
 import { UnitFactory } from './unit.factory';
+import { UnitCsvService } from '@/modules/unit/services/unit-csv.service';
 
 @Module({
   imports: [PrismaModule],
   controllers: [UnitController],
-  providers: [UnitService, OrderRepository, TransactionRepository, UnitFactory],
+  providers: [UnitService, OrderRepository, TransactionRepository, UnitFactory, UnitCsvService],
   exports: [UnitFactory],
 })
 export class UnitModule {}

--- a/src/modules/unit/unit.service.ts
+++ b/src/modules/unit/unit.service.ts
@@ -6,7 +6,6 @@ import {AggregateUnitDto} from "./dto/aggregate-unit.dto";
 import {UnitEntity} from "./entities/unit.entity";
 import {buildOrderWhere} from "./utils/order-filter.utils";
 import {UnitFactory} from "./unit.factory";
-import dayjs from "dayjs";
 
 @Injectable()
 export class UnitService {
@@ -51,30 +50,4 @@ export class UnitService {
             : items;
     }
 
-    async aggregateCsv(dto: AggregateUnitDto): Promise<string> {
-        const items = await this.aggregate(dto);
-        const header = [
-            "product",
-            "postingNumber",
-            "createdAt",
-            "status",
-            "margin",
-            "costPrice",
-            "totalServices",
-            "price"
-        ];
-        const rows = items.map((item) => {
-            return [
-                item.product,
-                item.postingNumber,
-                dayjs(item.createdAt).format("YYYY-MM"),
-                item.status,
-                item.margin,
-                item.costPrice,
-                item.totalServices,
-                item.price,
-            ].join(",");
-        });
-        return [header.join(","), ...rows].join("\n");
-    }
 }


### PR DESCRIPTION
## Summary
- move CSV generation for advertising into a dedicated service
- add a dedicated CSV service for unit aggregation exports
- update controllers and modules to consume the new CSV services

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d6dafddd2c832aade489dc7e0712c7