### PR TITLE
Adjust advertising sync start date selection

### DIFF
--- a/src/modules/advertising/advertising.repository.ts
+++ b/src/modules/advertising/advertising.repository.ts
@@ -88,4 +88,17 @@ export class AdvertisingRepository {
 
     return this.prisma.$transaction(operations);
   }
+
+  async findLatestDate(): Promise<string | null> {
+    const lastRecord = await this.prisma.advertising.findFirst({
+      orderBy: {
+        date: 'desc',
+      },
+      select: {
+        date: true,
+      },
+    });
+
+    return lastRecord?.date ?? null;
+  }
 }

--- a/src/modules/advertising/advertising.service.ts
+++ b/src/modules/advertising/advertising.service.ts
@@ -127,7 +127,9 @@ export class AdvertisingService {
     }
 
     async sync() {
-        const dates = getDatesUntilTodayUTC3('2025-09-23');
+        const latestDate = await this.advertisingRepository.findLatestDate();
+        const startDate = latestDate ?? '2024-10-01';
+        const dates = getDatesUntilTodayUTC3(startDate);
 
         for (const date of dates) {
             await this.getStatisticsExpense(date);


### PR DESCRIPTION
## Summary
- add repository helper to retrieve the most recent advertising record date
- update advertising sync to start from the last stored date or default to 2024-10-01

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6de552658832a98d0231982340ac1