### PR TITLE
Include all statuses in Unit orders CSV export

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import {NestFactory} from '@nestjs/core';
 import {AppModule} from './app.module';
 import {OzonAxiosExceptionFilter} from "@/api/filters/ozon-exception.filter";
-import {getDatesUntilTodayUTC3} from "@/shared/utils/date.utils";
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
@@ -9,10 +8,6 @@ async function bootstrap() {
     app.useGlobalFilters(new OzonAxiosExceptionFilter());
 
     await app.listen(3004);
-
-    console.log(getDatesUntilTodayUTC3('2025-05-01'));
-
-
 }
 
 bootstrap();

--- a/src/modules/unit/services/unit-csv.service.ts
+++ b/src/modules/unit/services/unit-csv.service.ts
@@ -48,10 +48,10 @@ export class UnitCsvService {
                 const key = `${item.sku}_${date}`;
                 const current =
                     grouped.get(key) ?? {
+                        sku: item.product,
                         ordersMoney: 0,
                         count: 0,
                         date,
-                        sku: item.sku,
                     };
 
                 current.ordersMoney += item.price;

--- a/src/modules/unit/services/unit-csv.service.ts
+++ b/src/modules/unit/services/unit-csv.service.ts
@@ -33,4 +33,47 @@ export class UnitCsvService {
         });
         return [header.join(','), ...rows].join('\n');
     }
+
+    async aggregateOrdersCsv(dto: AggregateUnitDto): Promise<string> {
+        const items = await this.unitService.aggregate(dto);
+        const header = ['ordersMoney', 'count', 'date', 'sku'];
+
+        const grouped = new Map<
+            string,
+            { ordersMoney: number; count: number; date: string; sku: string }
+        >();
+
+        items.forEach((item) => {
+                const date = dayjs(item.createdAt).format('YYYY-MM-DD');
+                const key = `${item.sku}_${date}`;
+                const current =
+                    grouped.get(key) ?? {
+                        ordersMoney: 0,
+                        count: 0,
+                        date,
+                        sku: item.sku,
+                    };
+
+                current.ordersMoney += item.price;
+                current.count += 1;
+
+                grouped.set(key, current);
+            });
+
+        const rows = Array.from(grouped.values())
+            .sort((a, b) => {
+                const dateDiff = a.date.localeCompare(b.date);
+                if (dateDiff !== 0) {
+                    return dateDiff;
+                }
+                return a.sku.localeCompare(b.sku);
+            })
+            .map((item) =>
+                [item.ordersMoney, item.count, item.date, item.sku]
+                    .map((value) => String(value))
+                    .join(','),
+            );
+
+        return [header.join(','), ...rows].join('\n');
+    }
 }

--- a/src/modules/unit/unit.controller.ts
+++ b/src/modules/unit/unit.controller.ts
@@ -21,4 +21,11 @@ export class UnitController {
   aggregateCsv(@Query() dto: AggregateUnitDto) {
     return this.unitCsvService.aggregateCsv(dto);
   }
+
+  @Get('csv/orders')
+  @Header('Content-Type', 'text/csv')
+  @Header('Content-Disposition', 'attachment; filename="unit-orders.csv"')
+  aggregateOrdersCsv(@Query() dto: AggregateUnitDto) {
+    return this.unitCsvService.aggregateOrdersCsv(dto);
+  }
 }

--- a/src/modules/unit/unit.service.ts
+++ b/src/modules/unit/unit.service.ts
@@ -49,5 +49,4 @@ export class UnitService {
             ? items.filter((item) => statuses.includes(item.status))
             : items;
     }
-
 }

--- a/test/unit.csv.service.spec.ts
+++ b/test/unit.csv.service.spec.ts
@@ -1,0 +1,100 @@
+import { UnitCsvService } from "@/modules/unit/services/unit-csv.service";
+import { UnitService } from "@/modules/unit/unit.service";
+import { OrderRepository } from "@/modules/order/order.repository";
+import { TransactionRepository } from "@/modules/transaction/transaction.repository";
+import { UnitFactory } from "@/modules/unit/unit.factory";
+import ordersFixture from "@/shared/data/orders.fixture";
+import dayjs from "dayjs";
+
+describe("UnitCsvService", () => {
+  let service: UnitService;
+  let csvService: UnitCsvService;
+  let orders: any[];
+  let transactions: any[];
+
+  beforeAll(() => {
+    orders = ordersFixture.map((o) => ({
+      ...o,
+      createdAt: new Date(o.createdAt),
+      inProcessAt: new Date(o.inProcessAt),
+      transactions: o.transactions.map((t) => ({
+        ...t,
+        date: new Date(t.date),
+      })),
+    }));
+    transactions = orders.flatMap((o) => o.transactions);
+    const orderRepository = {
+      findAll: jest.fn().mockResolvedValue(orders),
+    } as unknown as OrderRepository;
+    const transactionRepository = {
+      findByPostingNumbers: jest
+        .fn()
+        .mockImplementation((numbers: string[]) =>
+          Promise.resolve(
+            transactions.filter((t) => numbers.includes(t.postingNumber)),
+          ),
+        ),
+    } as unknown as TransactionRepository;
+    service = new UnitService(
+      orderRepository,
+      transactionRepository,
+      new UnitFactory(),
+    );
+    csvService = new UnitCsvService(service);
+  });
+
+  it("aggregates units by date and sku regardless of status", async () => {
+    const units = await service.aggregate({});
+    const expected = new Map<
+      string,
+      { ordersMoney: number; count: number; date: string; sku: string }
+    >();
+
+    units.forEach((unit) => {
+      const date = dayjs(unit.createdAt).format("YYYY-MM-DD");
+      const key = `${unit.sku}_${date}`;
+      const current =
+        expected.get(key) ?? {
+          ordersMoney: 0,
+          count: 0,
+          date,
+          sku: unit.sku,
+        };
+
+      current.ordersMoney += unit.price;
+      current.count += 1;
+
+      expected.set(key, current);
+    });
+
+    const csv = await csvService.aggregateOrdersCsv({});
+    const expectedRows = Array.from(expected.values())
+      .sort((a, b) => {
+        const dateDiff = a.date.localeCompare(b.date);
+        if (dateDiff !== 0) {
+          return dateDiff;
+        }
+        return a.sku.localeCompare(b.sku);
+      })
+      .map((item) =>
+        [item.ordersMoney, item.count, item.date, item.sku]
+          .map((value) => String(value))
+          .join(","),
+      );
+
+    const expectedCsv = ["ordersMoney,count,date,sku", ...expectedRows].join("\n");
+
+    expect(csv).toBe(expectedCsv);
+  });
+
+  it("returns only header when there are no units", async () => {
+    const emptyService = {
+      aggregate: jest.fn().mockResolvedValue([]),
+    } as unknown as UnitService;
+    const emptyCsvService = new UnitCsvService(emptyService);
+
+    const csv = await emptyCsvService.aggregateOrdersCsv({});
+
+    expect(csv).toBe("ordersMoney,count,date,sku");
+  });
+});


### PR DESCRIPTION
## Summary
- update the unit orders CSV aggregation to include every status instead of filtering to delivered units
- align the CSV service test to compute the expected aggregation regardless of status and keep the empty case coverage

## Testing
- npm test -- --runTestsByPath test/unit.csv.service.spec.ts *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d79b4d7104832a8e1a37e7cc15b09c