### PR TITLE
feat: calculate advertising spend per unit

### DIFF
--- a/src/modules/advertising/advertising.repository.ts
+++ b/src/modules/advertising/advertising.repository.ts
@@ -101,4 +101,24 @@ export class AdvertisingRepository {
 
     return lastRecord?.date ?? null;
   }
+
+  async findBySkusAndDateRange(
+    skus: string[],
+    dateFrom: string,
+    dateTo: string,
+  ) {
+    if (!skus.length) {
+      return [];
+    }
+
+    return this.prisma.advertising.findMany({
+      where: {
+        sku: { in: skus },
+        date: {
+          gte: dateFrom,
+          lte: dateTo,
+        },
+      },
+    });
+  }
 }

--- a/src/modules/unit/entities/unit.entity.ts
+++ b/src/modules/unit/entities/unit.entity.ts
@@ -13,6 +13,7 @@ export class UnitEntity extends OrderEntity {
   costPrice: number;
   totalServices: number;
   margin: number;
+  advertisingPerUnit: number;
   private statusOzon: OzonStatus | string;
 
   constructor(partial: Partial<UnitEntity>) {

--- a/src/modules/unit/services/unit-csv.service.ts
+++ b/src/modules/unit/services/unit-csv.service.ts
@@ -19,6 +19,7 @@ export class UnitCsvService {
             'costPrice',
             'totalServices',
             'price',
+            'advertisingPerUnit',
         ];
         const rows = items.map((item) => {
             return [
@@ -30,6 +31,7 @@ export class UnitCsvService {
                 item.costPrice,
                 item.totalServices,
                 item.price,
+                item.advertisingPerUnit,
             ].join(',');
         });
         return [header.join(','), ...rows].join('\n');

--- a/src/modules/unit/unit.factory.ts
+++ b/src/modules/unit/unit.factory.ts
@@ -5,12 +5,17 @@ import { OrderEntity } from '@/modules/order/entities/order.entity';
 
 @Injectable()
 export class UnitFactory {
-  createUnit(order: OrderEntity, transactions: Transaction[]): UnitEntity {
+  createUnit(
+    order: OrderEntity,
+    transactions: Transaction[],
+    additional: Partial<UnitEntity> = {},
+  ): UnitEntity {
     const uniqueTxs = [
       ...new Map(transactions.map((t) => [t.id, t])).values(),
     ];
     return new UnitEntity({
       ...order,
+      ...additional,
       transactions: uniqueTxs,
     });
   }

--- a/src/modules/unit/unit.module.ts
+++ b/src/modules/unit/unit.module.ts
@@ -6,11 +6,19 @@ import { OrderRepository } from '@/modules/order/order.repository';
 import { TransactionRepository } from '@/modules/transaction/transaction.repository';
 import { UnitFactory } from './unit.factory';
 import { UnitCsvService } from '@/modules/unit/services/unit-csv.service';
+import { AdvertisingRepository } from '@/modules/advertising/advertising.repository';
 
 @Module({
   imports: [PrismaModule],
   controllers: [UnitController],
-  providers: [UnitService, OrderRepository, TransactionRepository, UnitFactory, UnitCsvService],
+  providers: [
+    UnitService,
+    OrderRepository,
+    TransactionRepository,
+    UnitFactory,
+    UnitCsvService,
+    AdvertisingRepository,
+  ],
   exports: [UnitFactory],
 })
 export class UnitModule {}

--- a/test/unit.csv.service.spec.ts
+++ b/test/unit.csv.service.spec.ts
@@ -5,6 +5,7 @@ import { TransactionRepository } from "@/modules/transaction/transaction.reposit
 import { UnitFactory } from "@/modules/unit/unit.factory";
 import ordersFixture from "@/shared/data/orders.fixture";
 import dayjs from "dayjs";
+import { AdvertisingRepository } from "@/modules/advertising/advertising.repository";
 
 describe("UnitCsvService", () => {
   let service: UnitService;
@@ -35,10 +36,14 @@ describe("UnitCsvService", () => {
           ),
         ),
     } as unknown as TransactionRepository;
+    const advertisingRepository = {
+      findBySkusAndDateRange: jest.fn().mockResolvedValue([]),
+    } as unknown as AdvertisingRepository;
     service = new UnitService(
       orderRepository,
       transactionRepository,
       new UnitFactory(),
+      advertisingRepository,
     );
     csvService = new UnitCsvService(service);
   });

--- a/test/unit.service.spec.ts
+++ b/test/unit.service.spec.ts
@@ -4,12 +4,14 @@ import { TransactionRepository } from "@/modules/transaction/transaction.reposit
 import { UnitFactory } from "@/modules/unit/unit.factory";
 import ordersFixture from "@/shared/data/orders.fixture";
 import { CustomStatus } from "@/modules/unit/ts/custom-status.enum";
+import { AdvertisingRepository } from "@/modules/advertising/advertising.repository";
 
 describe("UnitService", () => {
   let service: UnitService;
   let orders: any[];
   let transactions: any[];
   let unitFactory: UnitFactory;
+  let advertisingRepository: jest.Mocked<AdvertisingRepository>;
 
   beforeAll(() => {
     orders = ordersFixture.map((o) => ({
@@ -34,11 +36,32 @@ describe("UnitService", () => {
           ),
         ),
     } as unknown as TransactionRepository;
+    advertisingRepository = {
+      findBySkusAndDateRange: jest.fn().mockResolvedValue([
+        {
+          id: "ad-1",
+          campaignId: "cmp-1",
+          sku: "1828048543",
+          date: "2024-01-05",
+          type: "search",
+          clicks: 0,
+          toCart: 0,
+          avgBid: 0,
+          minBidCpo: 0,
+          minBidCpoTop: 0,
+          competitiveBid: 0,
+          weeklyBudget: 0,
+          moneySpent: 800,
+          createdAt: new Date("2024-01-05T00:00:00.000Z"),
+        },
+      ]),
+    } as unknown as jest.Mocked<AdvertisingRepository>;
     unitFactory = new UnitFactory();
     service = new UnitService(
       orderRepository,
       transactionRepository,
       unitFactory,
+      advertisingRepository,
     );
   });
 
@@ -50,6 +73,7 @@ describe("UnitService", () => {
     expect(delivered?.status).toBe(CustomStatus.Delivered);
     expect(delivered?.costPrice).toBe(771);
     expect(delivered?.margin).toBeCloseTo(219);
+    expect(delivered?.advertisingPerUnit).toBeCloseTo(100);
 
     const returnUnit = result.find((item) => item.id === "delivered-positive");
     expect(returnUnit?.status).toBe(CustomStatus.Return);
@@ -70,5 +94,20 @@ describe("UnitService", () => {
     const spy = jest.spyOn(unitFactory, "createUnit");
     await service.aggregate({});
     expect(spy).toHaveBeenCalledTimes(orders.length);
+    const [order, orderTransactions, additional] = spy.mock.calls[0];
+    expect(order).toBeDefined();
+    expect(orderTransactions).toBeInstanceOf(Array);
+    expect(additional).toEqual(
+      expect.objectContaining({ advertisingPerUnit: expect.any(Number) }),
+    );
+  });
+
+  it("requests advertising statistics for the aggregated period", async () => {
+    await service.aggregate({});
+    expect(advertisingRepository.findBySkusAndDateRange).toHaveBeenCalledWith(
+      ["1828048543"],
+      "2024-01-01",
+      "2024-01-31",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- load monthly advertising totals per SKU during unit aggregation and compute per-unit DRR
- expose the advertisingPerUnit field on units and include it in CSV exports
- add repository helper and unit tests covering the new advertising calculations

## Testing
- npm test -- --runInBand *(fails: jest not found in PATH)*
- npm install *(fails: registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e6676e5c832ab376cc4283506c56