### PR TITLE
fix: stabilize unit advertising exports

### DIFF
--- a/src/modules/advertising/advertising.repository.ts
+++ b/src/modules/advertising/advertising.repository.ts
@@ -101,4 +101,24 @@ export class AdvertisingRepository {
 
     return lastRecord?.date ?? null;
   }
+
+  async findBySkusAndDateRange(
+    skus: string[],
+    dateFrom: string,
+    dateTo: string,
+  ) {
+    if (!skus.length) {
+      return [];
+    }
+
+    return this.prisma.advertising.findMany({
+      where: {
+        sku: { in: skus },
+        date: {
+          gte: dateFrom,
+          lte: dateTo,
+        },
+      },
+    });
+  }
 }

--- a/src/modules/unit/entities/unit.entity.ts
+++ b/src/modules/unit/entities/unit.entity.ts
@@ -13,11 +13,13 @@ export class UnitEntity extends OrderEntity {
   costPrice: number;
   totalServices: number;
   margin: number;
+  advertisingPerUnit: number;
   private statusOzon: OzonStatus | string;
 
   constructor(partial: Partial<UnitEntity>) {
     super(partial);
     Object.assign(this, partial);
+    this.advertisingPerUnit = partial.advertisingPerUnit ?? 0;
     this.statusOzon = (partial.status as OzonStatus) ?? "";
     const services = this.buildServices();
     const economy = this.calculateEconomy(services);

--- a/src/modules/unit/services/unit-csv.service.ts
+++ b/src/modules/unit/services/unit-csv.service.ts
@@ -19,6 +19,7 @@ export class UnitCsvService {
             'costPrice',
             'totalServices',
             'price',
+            'advertisingPerUnit',
         ];
         const rows = items.map((item) => {
             return [
@@ -30,6 +31,7 @@ export class UnitCsvService {
                 item.costPrice,
                 item.totalServices,
                 item.price,
+                item.advertisingPerUnit,
             ].join(',');
         });
         return [header.join(','), ...rows].join('\n');

--- a/src/modules/unit/unit.factory.ts
+++ b/src/modules/unit/unit.factory.ts
@@ -5,12 +5,17 @@ import { OrderEntity } from '@/modules/order/entities/order.entity';
 
 @Injectable()
 export class UnitFactory {
-  createUnit(order: OrderEntity, transactions: Transaction[]): UnitEntity {
+  createUnit(
+    order: OrderEntity,
+    transactions: Transaction[],
+    additional: Partial<UnitEntity> = {},
+  ): UnitEntity {
     const uniqueTxs = [
       ...new Map(transactions.map((t) => [t.id, t])).values(),
     ];
     return new UnitEntity({
       ...order,
+      ...additional,
       transactions: uniqueTxs,
     });
   }

--- a/src/modules/unit/unit.module.ts
+++ b/src/modules/unit/unit.module.ts
@@ -6,11 +6,19 @@ import { OrderRepository } from '@/modules/order/order.repository';
 import { TransactionRepository } from '@/modules/transaction/transaction.repository';
 import { UnitFactory } from './unit.factory';
 import { UnitCsvService } from '@/modules/unit/services/unit-csv.service';
+import { AdvertisingRepository } from '@/modules/advertising/advertising.repository';
 
 @Module({
   imports: [PrismaModule],
   controllers: [UnitController],
-  providers: [UnitService, OrderRepository, TransactionRepository, UnitFactory, UnitCsvService],
+  providers: [
+    UnitService,
+    OrderRepository,
+    TransactionRepository,
+    UnitFactory,
+    UnitCsvService,
+    AdvertisingRepository,
+  ],
   exports: [UnitFactory],
 })
 export class UnitModule {}

--- a/src/modules/unit/unit.service.ts
+++ b/src/modules/unit/unit.service.ts
@@ -1,4 +1,5 @@
 import {Injectable} from "@nestjs/common";
+import dayjs from "dayjs";
 import {OrderRepository} from "@/modules/order/order.repository";
 import {TransactionRepository} from "@/modules/transaction/transaction.repository";
 import {groupTransactionsByPostingNumber} from "@/shared/utils/transaction.utils";
@@ -6,6 +7,8 @@ import {AggregateUnitDto} from "./dto/aggregate-unit.dto";
 import {UnitEntity} from "./entities/unit.entity";
 import {buildOrderWhere} from "./utils/order-filter.utils";
 import {UnitFactory} from "./unit.factory";
+import {AdvertisingRepository} from "@/modules/advertising/advertising.repository";
+import {money} from "@/shared/utils/money.utils";
 
 @Injectable()
 export class UnitService {
@@ -13,6 +16,7 @@ export class UnitService {
         private readonly orderRepository: OrderRepository,
         private readonly transactionRepository: TransactionRepository,
         private readonly unitFactory: UnitFactory,
+        private readonly advertisingRepository: AdvertisingRepository,
     ) {
     }
 
@@ -20,6 +24,9 @@ export class UnitService {
         const where = buildOrderWhere(dto);
 
         const orders = await this.orderRepository.findAll(where);
+        if (!orders.length) {
+            return [];
+        }
         const postingNumbers = Array.from(
             new Set(
                 orders
@@ -33,12 +40,96 @@ export class UnitService {
 
         const byNumber = groupTransactionsByPostingNumber(transactions);
 
+        const skuMonthCounts = new Map<
+            string,
+            { sku: string; month: string; count: number }
+        >();
+        const skus = new Set<string>();
+        let minMonthStart: dayjs.Dayjs | null = null;
+        let maxMonthEnd: dayjs.Dayjs | null = null;
+
+        orders.forEach((order) => {
+            const orderDate = dayjs(order.createdAt);
+            const sku = order.sku?.trim();
+            if (!orderDate.isValid() || !sku) {
+                return;
+            }
+
+            const startOfMonth = orderDate.startOf("month");
+            const endOfMonth = orderDate.endOf("month");
+
+            if (!minMonthStart || startOfMonth.isBefore(minMonthStart)) {
+                minMonthStart = startOfMonth;
+            }
+            if (!maxMonthEnd || endOfMonth.isAfter(maxMonthEnd)) {
+                maxMonthEnd = endOfMonth;
+            }
+
+            const month = orderDate.format("YYYY-MM");
+            const key = `${sku}_${month}`;
+            const current = skuMonthCounts.get(key) ?? {
+                sku,
+                month,
+                count: 0,
+            };
+            current.count += 1;
+            skuMonthCounts.set(key, current);
+            skus.add(sku);
+        });
+
+        const advertisingTotals = new Map<string, number>();
+        if (skus.size && minMonthStart && maxMonthEnd) {
+            const ads = await this.advertisingRepository.findBySkusAndDateRange(
+                Array.from(skus),
+                minMonthStart.format("YYYY-MM-DD"),
+                maxMonthEnd.format("YYYY-MM-DD"),
+            );
+
+            ads.forEach((ad) => {
+                const adDate = dayjs(ad.date);
+                const sku = ad.sku?.trim();
+                if (!adDate.isValid() || !sku) {
+                    return;
+                }
+                const month = adDate.format("YYYY-MM");
+                const key = `${sku}_${month}`;
+                advertisingTotals.set(
+                    key,
+                    (advertisingTotals.get(key) ?? 0) + ad.moneySpent,
+                );
+            });
+        }
+
+        const advertisingPerUnitByKey = new Map<string, number>();
+        skuMonthCounts.forEach((value, key) => {
+            const totalAdvertisingDecimal = money(
+                advertisingTotals.get(key) ?? 0,
+            );
+            const perUnitDecimal =
+                value.count > 0
+                    ? totalAdvertisingDecimal
+                          .div(value.count)
+                          .toDecimalPlaces(2)
+                    : money(0);
+
+            advertisingPerUnitByKey.set(key, perUnitDecimal.toNumber());
+        });
+
         const items = orders.map((order) => {
             const numbers = [order.postingNumber, order.orderNumber];
             const orderTransactions = numbers.flatMap(
                 (num) => byNumber.get(num) ?? [],
             );
-            return this.unitFactory.createUnit(order, orderTransactions);
+            const month = dayjs(order.createdAt).format("YYYY-MM");
+            const sku = order.sku?.trim();
+            const key = sku ? `${sku}_${month}` : null;
+            const advertisingPerUnit = key
+                ? advertisingPerUnitByKey.get(key) ?? 0
+                : 0;
+
+            return this.unitFactory.createUnit(order, orderTransactions, {
+                advertisingPerUnit,
+            });
         });
 
         const statuses = dto.status

--- a/test/unit.service.spec.ts
+++ b/test/unit.service.spec.ts
@@ -104,10 +104,13 @@ describe("UnitService", () => {
 
   it("requests advertising statistics for the aggregated period", async () => {
     await service.aggregate({});
-    expect(advertisingRepository.findBySkusAndDateRange).toHaveBeenCalledWith(
-      ["1828048543"],
-      "2024-01-01",
-      "2024-01-31",
+    const [skus, dateFrom, dateTo] =
+      advertisingRepository.findBySkusAndDateRange.mock.calls[0];
+
+    expect(new Set(skus)).toEqual(
+      new Set(["1828048543", "сумка_кросбоди_черная"]),
     );
+    expect(dateFrom).toBe("2024-01-01");
+    expect(dateTo).toBe("2024-01-31");
   });
 });

--- a/test/unit.service.spec.ts
+++ b/test/unit.service.spec.ts
@@ -4,12 +4,14 @@ import { TransactionRepository } from "@/modules/transaction/transaction.reposit
 import { UnitFactory } from "@/modules/unit/unit.factory";
 import ordersFixture from "@/shared/data/orders.fixture";
 import { CustomStatus } from "@/modules/unit/ts/custom-status.enum";
+import { AdvertisingRepository } from "@/modules/advertising/advertising.repository";
 
 describe("UnitService", () => {
   let service: UnitService;
   let orders: any[];
   let transactions: any[];
   let unitFactory: UnitFactory;
+  let advertisingRepository: jest.Mocked<AdvertisingRepository>;
 
   beforeAll(() => {
     orders = ordersFixture.map((o) => ({
@@ -34,11 +36,32 @@ describe("UnitService", () => {
           ),
         ),
     } as unknown as TransactionRepository;
+    advertisingRepository = {
+      findBySkusAndDateRange: jest.fn().mockResolvedValue([
+        {
+          id: "ad-1",
+          campaignId: "cmp-1",
+          sku: "1828048543",
+          date: "2024-01-05",
+          type: "search",
+          clicks: 0,
+          toCart: 0,
+          avgBid: 0,
+          minBidCpo: 0,
+          minBidCpoTop: 0,
+          competitiveBid: 0,
+          weeklyBudget: 0,
+          moneySpent: 800,
+          createdAt: new Date("2024-01-05T00:00:00.000Z"),
+        },
+      ]),
+    } as unknown as jest.Mocked<AdvertisingRepository>;
     unitFactory = new UnitFactory();
     service = new UnitService(
       orderRepository,
       transactionRepository,
       unitFactory,
+      advertisingRepository,
     );
   });
 
@@ -50,6 +73,7 @@ describe("UnitService", () => {
     expect(delivered?.status).toBe(CustomStatus.Delivered);
     expect(delivered?.costPrice).toBe(771);
     expect(delivered?.margin).toBeCloseTo(219);
+    expect(delivered?.advertisingPerUnit).toBeCloseTo(100);
 
     const returnUnit = result.find((item) => item.id === "delivered-positive");
     expect(returnUnit?.status).toBe(CustomStatus.Return);
@@ -70,5 +94,20 @@ describe("UnitService", () => {
     const spy = jest.spyOn(unitFactory, "createUnit");
     await service.aggregate({});
     expect(spy).toHaveBeenCalledTimes(orders.length);
+    const [order, orderTransactions, additional] = spy.mock.calls[0];
+    expect(order).toBeDefined();
+    expect(orderTransactions).toBeInstanceOf(Array);
+    expect(additional).toEqual(
+      expect.objectContaining({ advertisingPerUnit: expect.any(Number) }),
+    );
+  });
+
+  it("requests advertising statistics for the aggregated period", async () => {
+    await service.aggregate({});
+    expect(advertisingRepository.findBySkusAndDateRange).toHaveBeenCalledWith(
+      ["1828048543"],
+      "2024-01-01",
+      "2024-01-31",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- default advertisingPerUnit to 0 on units so CSV output is always populated
- trim and guard SKUs when calculating monthly advertising spend per unit
- update CSV aggregation tests for the new column order and coverage

## Testing
- npm test -- --runInBand *(fails: jest not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e6676e5c832ab376cc4283506c56