### PR TITLE
Remove CSV synchronization prerequisites

### DIFF
--- a/src/modules/advertising/services/advertising-csv.service.ts
+++ b/src/modules/advertising/services/advertising-csv.service.ts
@@ -5,24 +5,9 @@ import {PRODUCTS} from "@/shared/constants/products";
 
 @Injectable()
 export class AdvertisingCsvService {
-    private synchronizationPromise: Promise<string> = null;
-
     constructor(private readonly advertisingService: AdvertisingService) {}
 
-    private async ensureSynchronized(): Promise<void> {
-        if (!this.synchronizationPromise) {
-            this.synchronizationPromise = this.advertisingService
-                .sync()
-                .finally(() => {
-                    this.synchronizationPromise = null;
-                });
-        }
-
-        await this.synchronizationPromise;
-    }
-
     async findManyCsv(filters: FilterAdvertisingDto): Promise<string> {
-        await this.ensureSynchronized();
         const items = await this.advertisingService.findMany(filters);
         const header = [
             'campaignId',

--- a/src/modules/unit/services/unit-csv.service.ts
+++ b/src/modules/unit/services/unit-csv.service.ts
@@ -2,53 +2,15 @@ import {Injectable} from '@nestjs/common';
 import {UnitService} from '@/modules/unit/unit.service';
 import {AggregateUnitDto} from '@/modules/unit/dto/aggregate-unit.dto';
 import dayjs from 'dayjs';
-import {OrderService} from '@/modules/order/order.service';
-import {TransactionService} from '@/modules/transaction/transaction.service';
-import {AdvertisingService} from '@/modules/advertising/advertising.service';
-import {GetPostingsDto} from '@/api/seller/dto/get-postings.dto';
 
 @Injectable()
 export class UnitCsvService {
-    private synchronizationPromise: Promise<void> | null = null;
-
     constructor(
         private readonly unitService: UnitService,
-        private readonly orderService: OrderService,
-        private readonly transactionService: TransactionService,
-        private readonly advertisingService: AdvertisingService,
     ) {
     }
 
-    private createDefaultOrderSyncDto(): GetPostingsDto {
-        return {
-            limit: 1000,
-            with: {
-                analytics_data: true,
-                financial_data: true,
-            },
-        };
-    }
-
-    private async performSynchronization(): Promise<void> {
-        await Promise.all([
-            this.transactionService.sync(),
-            this.orderService.sync(this.createDefaultOrderSyncDto()),
-            this.advertisingService.sync(),
-        ]);
-    }
-
-    private async ensureSynchronized(): Promise<void> {
-        if (!this.synchronizationPromise) {
-            this.synchronizationPromise = this.performSynchronization().finally(() => {
-                this.synchronizationPromise = null;
-            });
-        }
-
-        await this.synchronizationPromise;
-    }
-
     async aggregateCsv(dto: AggregateUnitDto): Promise<string> {
-        await this.ensureSynchronized();
         const items = await this.unitService.aggregate(dto);
         const header = [
             'product',
@@ -86,7 +48,6 @@ export class UnitCsvService {
     }
 
     async aggregateOrdersCsv(dto: AggregateUnitDto): Promise<string> {
-        await this.ensureSynchronized();
         const items = await this.unitService.aggregate(dto);
         const header = ['date', 'sku', 'ordersMoney', 'count'];
 

--- a/test/advertising.csv.service.spec.ts
+++ b/test/advertising.csv.service.spec.ts
@@ -3,7 +3,7 @@ import { AdvertisingService } from "@/modules/advertising/advertising.service";
 import { FilterAdvertisingDto } from "@/modules/advertising/dto/filter-advertising.dto";
 
 describe("AdvertisingCsvService", () => {
-  it("synchronizes data before generating csv", async () => {
+  it("generates csv without triggering synchronization", async () => {
     const filters = { campaignId: "campaign-1" } as FilterAdvertisingDto;
     const advertisingService = {
       sync: jest.fn().mockResolvedValue("OK"),
@@ -31,7 +31,7 @@ describe("AdvertisingCsvService", () => {
 
     const csv = await service.findManyCsv(filters);
 
-    expect(advertisingService.sync).toHaveBeenCalledTimes(1);
+    expect(advertisingService.sync).not.toHaveBeenCalled();
     expect(advertisingService.findMany).toHaveBeenCalledWith(filters);
     expect(csv.split("\n")[0]).toBe(
       "campaignId,sku,type,views,moneySpent,toCart,competitiveBid,weeklyBudget,minBidCpo,minBidCpoTop,avgBid,empty,clicks,date",

--- a/test/unit.csv.service.spec.ts
+++ b/test/unit.csv.service.spec.ts
@@ -6,18 +6,12 @@ import { UnitFactory } from "@/modules/unit/unit.factory";
 import ordersFixture from "@/shared/data/orders.fixture";
 import dayjs from "dayjs";
 import { AdvertisingRepository } from "@/modules/advertising/advertising.repository";
-import { OrderService } from "@/modules/order/order.service";
-import { TransactionService } from "@/modules/transaction/transaction.service";
-import { AdvertisingService } from "@/modules/advertising/advertising.service";
 
 describe("UnitCsvService", () => {
   let service: UnitService;
   let csvService: UnitCsvService;
   let orders: any[];
   let transactions: any[];
-  let orderService: jest.Mocked<Pick<OrderService, "sync">>;
-  let transactionService: jest.Mocked<Pick<TransactionService, "sync">>;
-  let advertisingService: jest.Mocked<Pick<AdvertisingService, "sync">>;
 
   beforeAll(() => {
     orders = ordersFixture.map((o) => ({
@@ -58,22 +52,7 @@ describe("UnitCsvService", () => {
       advertisingRepository,
     );
 
-    orderService = {
-      sync: jest.fn().mockResolvedValue(0),
-    } as unknown as jest.Mocked<Pick<OrderService, "sync">>;
-    transactionService = {
-      sync: jest.fn().mockResolvedValue(0),
-    } as unknown as jest.Mocked<Pick<TransactionService, "sync">>;
-    advertisingService = {
-      sync: jest.fn().mockResolvedValue("OK"),
-    } as unknown as jest.Mocked<Pick<AdvertisingService, "sync">>;
-
-    csvService = new UnitCsvService(
-      service,
-      orderService,
-      transactionService,
-      advertisingService,
-    );
+    csvService = new UnitCsvService(service);
   });
 
   it("aggregates units by date and sku regardless of status", async () => {
@@ -118,37 +97,17 @@ describe("UnitCsvService", () => {
     const expectedCsv = ["date,sku,ordersMoney,count", ...expectedRows].join("\n");
 
     expect(csv).toBe(expectedCsv);
-    expect(orderService.sync).toHaveBeenCalled();
-    expect(transactionService.sync).toHaveBeenCalled();
-    expect(advertisingService.sync).toHaveBeenCalled();
   });
 
   it("returns only header when there are no units", async () => {
     const emptyService = {
       aggregate: jest.fn().mockResolvedValue([]),
     } as unknown as UnitService;
-    const emptyOrderService = {
-      sync: jest.fn().mockResolvedValue(0),
-    } as unknown as jest.Mocked<Pick<OrderService, "sync">>;
-    const emptyTransactionService = {
-      sync: jest.fn().mockResolvedValue(0),
-    } as unknown as jest.Mocked<Pick<TransactionService, "sync">>;
-    const emptyAdvertisingService = {
-      sync: jest.fn().mockResolvedValue("OK"),
-    } as unknown as jest.Mocked<Pick<AdvertisingService, "sync">>;
-    const emptyCsvService = new UnitCsvService(
-      emptyService,
-      emptyOrderService,
-      emptyTransactionService,
-      emptyAdvertisingService,
-    );
+    const emptyCsvService = new UnitCsvService(emptyService);
 
     const csv = await emptyCsvService.aggregateOrdersCsv({});
 
     expect(csv).toBe("date,sku,ordersMoney,count");
-    expect(emptyOrderService.sync).toHaveBeenCalled();
-    expect(emptyTransactionService.sync).toHaveBeenCalled();
-    expect(emptyAdvertisingService.sync).toHaveBeenCalled();
   });
 
   it("includes advertisingPerUnit column in unit export", async () => {


### PR DESCRIPTION
## Summary
- remove synchronization steps from the advertising CSV service before generating exports
- simplify the unit CSV service to rely solely on aggregated data without triggering sync operations
- update related unit tests to reflect the new behavior

## Testing
- npm test -- --runTestsByPath test/advertising.csv.service.spec.ts test/unit.csv.service.spec.ts *(fails: jest binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d800d787a8832a9cb08b120deccb6a